### PR TITLE
Removed secure from https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Live website
 This code base is for the website:
 
-[https://heliopython.org](https://heliopython.org)
+[http://heliopython.org](https://heliopython.org)
 
 The website is based on Jekyll, which automatically builds changes on GitHub.
 You don't have to run Jekyll yourself to make changes.


### PR DESCRIPTION
Issued a connection not private warning on my browser. If this is the case, we might want to indicate as such in the url.