### PR TITLE
Update meetings.md

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -8,43 +8,34 @@ order: 2
 
 Meetings and telecon times are available as a [Google calendar](https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
-### 2019 Python in Heliophysics Working Group Meeting 
+### Community Meetings
 
-The second meeting of the heliopython community is planned to be held in Boulder, Colorado from May 21-23, 2019. The
-meeting page can be found [here](http://lasp.colorado.edu/home/pyhc-meeting/).
+#### 2019 Python in Heliophysics Community Meeting 
 
-### AGU Session
-* IN11B: Application Development in Python for Solar and Space Physics Posters, Monday, 10 December 2018  08:00 - 12:20
+The second PyHC meeting was held in Boulder, Colorado from May 21-23, 2019. 
+* [Meeting materials](https://drive.google.com/drive/u/0/folders/171Ba3Mq3MIaEXoc9X91gZhaXHVjoJde2)
 
-### 2018 Python in Heliophysics Working Group Meeting 
+#### 2018 Python in Heliophysics Working Group Meeting 
 
 The first meeting of the heliopython community was held in Boulder, Colorado from November 13-15, 2018. 
 * [Meeting Report](https://docs.google.com/document/d/1ejP0kaibf6DRxjYJNmPrF1t3Nl21r0pC1FuDhu0hPnM/edit?usp=sharing)
 * [Presentations and Documents](https://drive.google.com/open?id=1snib9D8PcSaPByMqrAx8_4b05RfsTh58)
 * [Python in Heliophysics Community (PyHC) Standards](https://github.com/heliophysicsPy/standards/blob/master/standards.md)
 
+### Related Meetings
+
+* [CEDAR workshop](http://cedarweb.vsp.ucar.edu/wiki/index.php/2019_Workshop:Python_for_Space_Science)
+* SHINE 2019: proposed workshop
+
+#### AGU Sessions
+
+* Proposed [AGU 2019](https://events.jspargo.com/AGU19/Public/enter.aspx) session
+* [IN11B: Application Development in Python for Solar and Space Physics Posters](https://agu.confex.com/agu/fm18/meetingapp.cgi/Session/46412), Monday, 10 December 2018  08:00-12:20
+
 ### Telecons
 
-* [2019-04-05](https://drive.google.com/open?id=18c5TSAve2JXQV9LthQXYGlD524b_nf2Q)
-  * Continuing discussion of proposals and upcoming meetings
-* [2019-02-08](https://drive.google.com/open?id=1XEQaV6c6kXDokhJ83JX18dN5DQVt2I_x)
-  * Discussion of HDEE call
-* [2018-11-30](https://docs.google.com/document/d/1Pk0XWjqbjpe9_xln9ZqQ_00o6wVDXIpjyhFq-moUBC0/edit#heading=h.i5bghtfdk9hv)
-  * Discussion of standards document
-* [2018-10-19](https://drive.google.com/open?id=1VgpR6eLZ-JZ2Y9NQrxy-kw0DVKdVLTYV)
-  * Went over agenda for November meeting.  
-* [2018-10-05](https://drive.google.com/open?id=1_vZ_1TI1P5vtgmRbU01Ufy6FEREi5fOv)
-  * Reviewed and revised November meeting agenda
-  * Reminder: AGU session is scheduled for Monday morning, Dec. 10
-  * Dan Ryan gave a demo of ndcube.
-* [2018-09-21](https://drive.google.com/open?id=1KVvFam8zk_LG_UEZOEigB9l1nJkegZ8A)
-  * Presentation by Dan Ryan on ndcube.
-* [2018-09-07](http://datashop.elasticbeanstalk.com/hapi)
-  * Presentation by Jon Vandegriff on HAPI.
-* [2018-08-24](https://drive.google.com/open?id=19eL7iJdzwjvgvo1L3EpHAaJYkeRMflD_)
-  * Planning for November meeting
-  * Reviewed agenda
-  * Discussed possibility of unconference sessions an writing a report with findings and recommendations
-* [2018-08-10](https://drive.google.com/open?id=1CHZm5NbicoB0djvpQXZjDagVBjQMIjj4)
-* [2018-07-27](https://drive.google.com/open?id=15-W7BSp-BZ9B08sHXm5LfJIw-4XVfLoN)
-* [2018-07-06](https://drive.google.com/open?id=1XppfiUg2BSxfF1opF8SW2IG4sFqzESPI)
+Telecons are held every other week on Fridays at 10:00 AM Mountain time. 
+
+Telecon presentations and notes can be found in the [Telecons section](https://drive.google.com/drive/u/0/folders/1AhFUli3SGW9DHvIh81tFxPMgLtYSPXDm) of the Google drive. 
+
+


### PR DESCRIPTION
Removed telecon list and just linked to google drive contents. 
Updated AGU, SHINE, CEDAR meeting info.
Added May 2019 PyHC meeting info and link.