### PR TITLE
Updating the contact page

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -5,8 +5,12 @@ permalink: /contact/
 order: 6
 ---
 ## Mailing List
-There is a mailing list for discussions. To be added to the mailing list for this project,
-please contact Alex DeWolfe at LASP, [alex.dewolfe@lasp.colorado.edu](mailto:alex.dewolfe@lasp.colorado.edu).
+There is a Google Groups mailing list for discussions. To be added to the mailing list for this project, please do the following:<br />
+1) Ask to join the group at [this link](https://groups.google.com/group/pyhc-list/subscribe)<br />
+2) You should receive a follow up email from doing Step 1. In that email, click 'Join This Group' to confirm your subscription. It should then send you back to the Google Groups page, with a message saying your email has been added to the groups.<br />
+
+Once you've joined, you should be able to send emails to the group via [pyhc-list@googlegroups.com](mailto: pyhc-list@googlegroups.com)<br />
+If the above steps do not work for you, please contact Julie Barnum at LASP, [Julie.Barnum@lasp.colorado.edu](mailto:Julie.Barnum@lasp.colorado.edu)
 
 ## Chat room
 For more informal discussions and questions there is a chat room to enable live chat between users and developers. The chat is hosted on matrix and clicking the following [link](https://riot.im/app/#/room/#heliopython:openastronomy.org) will open a browser window with the chat interface. There is no need to install any software.


### PR DESCRIPTION
Updated the page to now show instructions for how to join our Google Group mailing list, instead of the LASP-managed Sympa mailing list.