### PR TITLE
Fix project cards

### DIFF
--- a/_includes/project_cards.html
+++ b/_includes/project_cards.html
@@ -1,16 +1,16 @@
 <div class="container-fluid">
   <ul class="nav nav-tabs">
     <li class="nav-item">
-        <a href="#table" class="nav-link active" data-toggle="tab">Table</a>
+        <a href="#table{{id}}" class="nav-link active" data-toggle="tab">Table</a>
     </li>
       <li class="nav-item">
-          <a href="#cards" class="nav-link" data-toggle="tab">Cards</a>
+          <a href="#cards{{id}}" class="nav-link" data-toggle="tab">Cards</a>
       </li>
   </ul>
 
   <div class="tab-content">
 
-    <div class="tab-pane fade show active" id="table">
+    <div class="tab-pane fade show active" id="table{{id}}">
         <table class="table table-striped">
           <thead class="thead-dark">
             <tr>
@@ -38,7 +38,7 @@
           </table>
       </div>
 
-      <div class="tab-pane fade" id="cards">
+      <div class="tab-pane fade" id="cards{{id}}">
         <div class="card-columns">
         {% for project in {{include.sorted_projects}} %}
             <div class="card">
@@ -64,3 +64,4 @@
     </div>
 
   </div>
+</div>

--- a/_pages/projects.html
+++ b/_pages/projects.html
@@ -10,11 +10,10 @@ order: 5
   and conform to the HeliophysicsPy community standards.
 </p>
 {% assign sorted_projects = site.data.projects_core | sort_natural:'name' %}
-{% include project_cards.html sorted_projects=sorted_projects %}
-
+{% assign id = 1 %}
+{% include project_cards.html sorted_projects=sorted_projects id=id %}
 
 <h3> Other packages </h3>
 {% assign sorted_projects = site.data.projects | sort_natural:'name' %}
-{% include project_cards.html sorted_projects=sorted_projects %}
-
-</div>
+{% assign id = 2 %}
+{% include project_cards.html sorted_projects=sorted_projects id=id %}


### PR DESCRIPTION
Fixes #64.

The issue was that the ids for the "Core" and "Other" project tabs were conflicting. This injects an additional variable to make the ids unique. If someone has a more elegant fix for this, please chime in! This feels a bit hacky.