### PR TITLE
fixing typo in spring meeting info

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -13,7 +13,7 @@ Telecons are held approximately every two weeks on Mondays at 09:00 AM Mountain 
 Meetings and telecon times are available as a [Google calendar](https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
 ### Community Meetings
-2020 Fall Python in Heliophysics Community Meeting, April 27-27, 2020 (at the CfA in Cambridge, MA)
+2020 Spring Python in Heliophysics Community Meeting, April 27-27, 2020 (at the CfA in Cambridge, MA)
 
 2019 Fall Python in Heliophysics Community Meeting, November 4-6, 2019 (at LASP).
 * [Presentations and Documents](https://drive.google.com/drive/u/0/folders/1lSM0DwLuKli1Rv9eKYe0vBVB_V8_9wKB)


### PR DESCRIPTION
says Fall 2020 meeting, but is the Spring 2020 meeting