### PR TITLE
Update SpacePy docs site to github.io

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -173,8 +173,8 @@
 
 - name: "SpacePy"
   description: "Space science library for Python. Includes file I/O, time and coordinate conversions, common analysis techniques."
-  logo: "https://pythonhosted.org/SpacePy/_static/spacepy_logo.jpg"
-  docs: "https://pythonhosted.org/SpacePy"
+  logo: "https://spacepy.github.io/_static/spacepy_logo.jpg"
+  docs: "https://spacepy.github.io/"
   code: "https://github.com/spacepy/spacepy"
   contact: "Steve Morley"
   keywords: ["ionosphere_thermosphere_mesosphere","magnetosphere","general"]


### PR DESCRIPTION
The pythonhosted.org SpacePy docs haven't been definitive for some time now (and I was finally able to get those deleted.) This PR updates the links to the correct site on github.