### PR TITLE
Fix typo in meeting dates & add link to SHINE tutorial description

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -30,7 +30,7 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 ### Related Meetings
 
 * [CEDAR workshop](http://cedarweb.vsp.ucar.edu/wiki/index.php/2019_Workshop:Python_for_Space_Science)
-* SHINE 2019: proposed workshop
+* SHINE 2019 Tutorial: [Using SunPy and HelioPy to work with remote and in situ data](https://shinecon.org/shine2019/session2019.php#session22)
 
 #### AGU Sessions
 

--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -13,7 +13,7 @@ Telecons are held approximately every two weeks on Mondays at 09:00 AM Mountain 
 Meetings and telecon times are available as a [Google calendar](https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
 ### Community Meetings
-2020 Spring Python in Heliophysics Community Meeting, April 27-27, 2020 (at the CfA in Cambridge, MA)
+2020 Spring Python in Heliophysics Community Meeting, April 27-29, 2020 (at the [Center for Astrophysics](https://www.cfa.harvard.edu/) in Cambridge, MA)
 
 2019 Fall Python in Heliophysics Community Meeting, November 4-6, 2019 (at LASP).
 * [Presentations and Documents](https://drive.google.com/drive/u/0/folders/1lSM0DwLuKli1Rv9eKYe0vBVB_V8_9wKB)


### PR DESCRIPTION
We should merge this one soon to make sure the information is accurate on the meeting webpage.  