### PR TITLE
Adding blog post about Spring 2020 Meeting

### DIFF
--- a/_posts/2020-02-27-spring-2020-meeting-announced.markdown
+++ b/_posts/2020-02-27-spring-2020-meeting-announced.markdown
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "PyHC Spring 2020 Meeting Dates Announced."
+author: jibarnum
+---
+
+PyHC serves as a community knowledge base for performing heliophysics research in Python, aiming to provide a variety of tutorials, resources, a list of useful packages, general discussion, and advice. Twice yearly, PyHC meets in person. These meetings are open to anyone from individuals already utilizing Python heavily in developing open-source heliophysics packages, as well as those who are just getting into using Python and open source development. 
+
+**PyHC will be hosting its first meeting of 2020 at the [Center for Astrophysics (CfA)](https://www.cfa.harvard.edu/) in Cambridge, MA, Monday, April 27th, 2020 - Wednesday, April 29th, 2020.** We’ll discuss PyHC Project updates, have unconferences (based on what the group is interested in), provide some Python tutorials, as well as discuss our governance structure.
+
+A meeting website is coming shortly, check back here for that URL in a day or two. **Registration, which is free, but required, can be found [here](https://forms.gle/HXdTtvYhjhbtZz8b7).** If you’d like to join our mailing list to learn more information about the meeting and other upcoming events, please see the [PyHC Contact page](http://heliopython.org/contact/) for instructions. We also have a [Riot chat group]( https://riot.im/app/#/room/#heliopython:openastronomy.org
+) where we discuss various PyHC issues/topics, as well as discussing other Python-related questions.
+
+**Registration Deadline: COB, Thursday, April 9th**


### PR DESCRIPTION
Adding a blog post for the Spring 2020 Meeting. This can be distributed to whomever seems relevant.