### PR TITLE
Correct link in README by changing HTTPS to HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Live website
 This code base is for the website:
 
-[http://heliopython.org](https://heliopython.org)
+[http://heliopython.org](http://heliopython.org)
 
 The website is based on Jekyll, which automatically builds changes on GitHub.
 You don't have to run Jekyll yourself to make changes.


### PR DESCRIPTION
This addresses issue #93.

The URL text had HTTP in the URL but the link embedded behind the text used HTTPS. I assume that was a typo. 