### PR TITLE
GitLab icons for GitLab repos

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -292,7 +292,7 @@
 - name: "MadrigalWeb"
   url: "http://cedar.openmadrigal.org"
   description: "Access data from any Madrigal database."
-  code: "https://pypi.python.org/pypi/madrigalWeb"
+  code: "https://pypi.org/project/madrigalWeb"
   contact: "Bill Rideout"
   keywords: ["ionosphere_thermosphere_mesosphere","general"]
 

--- a/_includes/project_cards.html
+++ b/_includes/project_cards.html
@@ -34,7 +34,7 @@
             <tr>
               <th>{{ project.name }}</th>
               <td>{{ project.description }}</td>
-              <td><a href="{{ project.code }}" class="card-link"><i class="fab fa-github fa-2x"></i></a></td>
+              <td><a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab" %}gitlab{% else %}github{% endif %} fa-2x"></i></a></td>
               <td>{% if project.docs != blank %}<a href="{{ project.docs }}" class="card-link"><i class="fas fa-book fa-2x"></i></a>{% endif %}</td>
               <td>{% if project.url != blank %}<a href="{{ project.url }}" class="card-link"><i class="fas fa-globe fa-2x"></i></a>{% endif %}</td>
               <td>{{ project.contact }}</td>
@@ -66,7 +66,7 @@
                     </p>
                 </div>
                 <div class="card-footer text-right">
-                    <a href="{{ project.code }}" class="card-link"><i class="fab fa-github fa-2x"></i></a>
+                    <a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab" %}gitlab{% else %}github{% endif %} fa-2x"></i></a>
                     {% if project.docs != blank %}<a href="{{ project.docs }}" class="card-link"><i class="fas fa-book fa-2x"></i></a>{% endif %}
                     {% if project.url != blank %}<a href="{{ project.url }}" class="card-link"><i class="fas fa-globe fa-2x"></i></a>{% endif %}
                 </div>

--- a/_includes/project_cards.html
+++ b/_includes/project_cards.html
@@ -34,7 +34,17 @@
             <tr>
               <th>{{ project.name }}</th>
               <td>{{ project.description }}</td>
-              <td><a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab.com" %}gitlab{% else %}{% if project.code contains "pypi.org" %}python{% else %}github{% endif %}{% endif %} fa-2x"></i></a></td>
+              <td><a href="{{ project.code }}" 
+                {%- capture site_icon -%}
+                  {%- if project.code contains "gitlab.com" -%}
+                    gitlab
+                  {%- elsif project.code contains "pypi.org" -%}
+                    python
+                  {%- else -%}
+                    github
+                  {%- endif -%}
+                {%- endcapture -%}
+                class="card-link"><i class="fab fa-{{site_icon}} fa-2x"></i></a></td>
               <td>{% if project.docs != blank %}<a href="{{ project.docs }}" class="card-link"><i class="fas fa-book fa-2x"></i></a>{% endif %}</td>
               <td>{% if project.url != blank %}<a href="{{ project.url }}" class="card-link"><i class="fas fa-globe fa-2x"></i></a>{% endif %}</td>
               <td>{{ project.contact }}</td>
@@ -66,7 +76,17 @@
                     </p>
                 </div>
                 <div class="card-footer text-right">
-                    <a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab.com" %}gitlab{% else %}{% if project.code contains "pypi.org" %}python{% else %}github{% endif %}{% endif %} fa-2x"></i></a>
+                    <a href="{{ project.code }}" 
+                      {%- capture site_icon -%}
+                        {%- if project.code contains "gitlab.com" -%}
+                          gitlab
+                        {%- elsif project.code contains "pypi.org" -%}
+                          python
+                        {%- else -%}
+                          github
+                        {%- endif -%}
+                      {%- endcapture -%}
+                      class="card-link"><i class="fab fa-{{site_icon}} fa-2x"></i></a>
                     {% if project.docs != blank %}<a href="{{ project.docs }}" class="card-link"><i class="fas fa-book fa-2x"></i></a>{% endif %}
                     {% if project.url != blank %}<a href="{{ project.url }}" class="card-link"><i class="fas fa-globe fa-2x"></i></a>{% endif %}
                 </div>

--- a/_includes/project_cards.html
+++ b/_includes/project_cards.html
@@ -34,7 +34,7 @@
             <tr>
               <th>{{ project.name }}</th>
               <td>{{ project.description }}</td>
-              <td><a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab.com" %}gitlab{% else %}github{% endif %} fa-2x"></i></a></td>
+              <td><a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab.com" %}gitlab{% else %}{% if project.code contains "pypi.org" %}python{% else %}github{% endif %}{% endif %} fa-2x"></i></a></td>
               <td>{% if project.docs != blank %}<a href="{{ project.docs }}" class="card-link"><i class="fas fa-book fa-2x"></i></a>{% endif %}</td>
               <td>{% if project.url != blank %}<a href="{{ project.url }}" class="card-link"><i class="fas fa-globe fa-2x"></i></a>{% endif %}</td>
               <td>{{ project.contact }}</td>
@@ -66,7 +66,7 @@
                     </p>
                 </div>
                 <div class="card-footer text-right">
-                    <a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab.com" %}gitlab{% else %}github{% endif %} fa-2x"></i></a>
+                    <a href="{{ project.code }}" class="card-link"><i class="fab fa-{% if project.code contains "gitlab.com" %}gitlab{% else %}{% if project.code contains "pypi.org" %}python{% else %}github{% endif %}{% endif %} fa-2x"></i></a>
                     {% if project.docs != blank %}<a href="{{ project.docs }}" class="card-link"><i class="fas fa-book fa-2x"></i></a>{% endif %}
                     {% if project.url != blank %}<a href="{{ project.url }}" class="card-link"><i class="fas fa-globe fa-2x"></i></a>{% endif %}
                 </div>


### PR DESCRIPTION
This PR adds a conditional that alters the FontAwesome icon for the code repo if the repo is on GitLab. This is a bit hacky and doesn't generalize well to other kinds of repos (e.g. Bitbucket). If there is a better option for doing this, I'm very open to it.