### PR TITLE
Move SpacePy to core packages

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -222,20 +222,6 @@
   description: Dowload & plot Scanning Doppler Interferometer data from PI Mark Conde's instruments.
   contact: Michael Hirsch
   keywords: ["ionosphere_thermosphere_mesosphere","specific"]
-
-- name: "SpacePy"
-  description: "Space science library for Python. Includes file I/O, time and coordinate conversions, common analysis techniques."
-  logo: "https://spacepy.github.io/_static/spacepy_logo.jpg"
-  docs: "https://spacepy.github.io/"
-  code: "https://github.com/spacepy/spacepy"
-  contact: "Steve Morley"
-  keywords: ["ionosphere_thermosphere_mesosphere","magnetosphere","general"]
-  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
-  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   
 - name: ScienceDates
   code: https://github.com/scivision/sciencedates

--- a/_data/projects_core.yml
+++ b/_data/projects_core.yml
@@ -57,3 +57,17 @@
   software_maturity: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
+- name: "SpacePy"
+  description: "Space science library for Python. Includes file I/O, time and coordinate conversions, common analysis techniques."
+  logo: "https://spacepy.github.io/_static/spacepy_logo.jpg"
+  docs: "https://spacepy.github.io/"
+  code: "https://github.com/spacepy/spacepy"
+  contact: "Steve Morley"
+  keywords: ["ionosphere_thermosphere_mesosphere","magnetosphere","general"]
+  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]


### PR DESCRIPTION
This PR moves SpacePy from "projects" to "core projects". The question came up on the call today why SpacePy wasn't listed as core; it's designed as a broadly useful (rather than task-specific package) and in particular the CDF support was cited as a general capability.

I'm submitting this PR since the SpacePy team supports moving SpacePy to the core section, but further discussion can certainly happen here.