### PR TITLE
Replace two HTTP logo URLs with HTTPS URLs

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -38,7 +38,7 @@
 - name: DASCutils
   code: https://github.com/scivision/dascutils
   description: Digital All Sky Camera utilities, for camera at Poker Flat Research Range and elsewhere
-  logo: http://optics.gi.alaska.edu/optics/sites/default/files/logo.png
+  logo: https://i.ibb.co/JKLF4FB/logo.jpg
   contact: Michael Hirsch
   keywords: ["ionosphere_thermosphere_mesosphere","specific"]
 
@@ -246,7 +246,7 @@
 - name: THEMISasi
   code: https://github.com/scivision/themisasi
   description: Read & Plot THEMIS ASI 256x256 "high resolution" GBO ground-based imager data
-  logo: http://themis.ssl.berkeley.edu/gbo/thm_gbo_logo.png
+  logo: https://i.ibb.co/Jyx1nNd/thm-gbo-logo.jpg
   contact: Michael Hirsch
   keywords: ["magnetosphere","ionosphere_thermosphere_mesosphere","specific"]
 


### PR DESCRIPTION
I noticed that every PR in this project fails the automated checks because of mixed HTTP/HTTPS content. This has apparently been an issue for a while. Upon closer inspection, the offending content is two logos: the logo for DASCutils and the logo for THEMISasi.

I decided to take executive action on this and host these two logos securely. This PR swaps the old HTTP URLs for new HTTPS ones, which will fix the automated checks for all our PRs. 👍 