### PR TITLE
Commit Package Review Template

### DIFF
--- a/_pyhc_projects/package_review_template.md
+++ b/_pyhc_projects/package_review_template.md
@@ -1,24 +1,26 @@
+# Package Review Template
+
 This is based on the [PyHC Project Review Guidelines](https://github.com/heliophysicsPy/heliophysicsPy.github.io/blob/master/_pyhc_projects/pyhc_project_grading_guidelines.md). Numbers in square brackets refer to the item in the [PyHC Standards](https://github.com/heliophysicsPy/standards/blob/master/standards.md). See the [Contributing Guide](https://github.com/heliophysicsPy/heliophysicsPy.github.io/blob/master/_pyhc_projects/adding_to_pyhc_project_list.md) for instructions to add a project to the PyHC Project List.
 
-1. Community
+**1. Community**
 - [ ] All code is available and developed publicly [[2](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Code is not duplicated [[12](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] The package is not forked from an existing project [[12](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Package provides contribution guidelines [[13](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Package has a code of conduct [[15](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 
-2. Documentation
+**2. Documentation**
 - [ ] All functions, classes, and modules have documentation strings (docstrings) provided in a standard conventions (e.g. [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)) [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] High level documentation is provided as guides, tutorials, and developer docs [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Documentation is provided in version control with the code [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Documentation is available online in a readable form [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 
-3. Testing
+**3. Testing**
 - [ ] Package has unit tests of individual components (e.g. functions, classes) [[9](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Package has integration tests that test the interaction between components that covers most of the code [[9](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Testing coverage is measured [[9](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 
-4. Software Maturity
+**4. Software Maturity**
 - [ ] All code is organized and provided as part of installable Python packages [[1](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Project has consistent and stable releases [[3](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Project releases are available through [PyPI](https://pypi.org) and [Conda](https://docs.conda.io/en/latest/) [[3](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
@@ -29,9 +31,9 @@ This is based on the [PyHC Project Review Guidelines](https://github.com/helioph
 - [ ] Project imports the minimum number of packages necessary [[10](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Binary files are added to the package repository only when necessary [[14](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 
-5. Python 3
+**5. Python 3**
 - [ ] Package is compatible with python 3 [[11](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 
-6. License
+**6. License**
 - [ ] Project has a license [[5](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
 - [ ] Project has a permissive license for open source scientific software [[5](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]

--- a/_pyhc_projects/package_review_template.md
+++ b/_pyhc_projects/package_review_template.md
@@ -1,0 +1,37 @@
+This is based on the [PyHC Project Review Guidelines](https://github.com/heliophysicsPy/heliophysicsPy.github.io/blob/master/_pyhc_projects/pyhc_project_grading_guidelines.md). Numbers in square brackets refer to the item in the [PyHC Standards](https://github.com/heliophysicsPy/standards/blob/master/standards.md). See the [Contributing Guide](https://github.com/heliophysicsPy/heliophysicsPy.github.io/blob/master/_pyhc_projects/adding_to_pyhc_project_list.md) for instructions to add a project to the PyHC Project List.
+
+1. Community
+- [ ] All code is available and developed publicly [[2](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Code is not duplicated [[12](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] The package is not forked from an existing project [[12](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Package provides contribution guidelines [[13](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Package has a code of conduct [[15](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+
+2. Documentation
+- [ ] All functions, classes, and modules have documentation strings (docstrings) provided in a standard conventions (e.g. [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)) [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] High level documentation is provided as guides, tutorials, and developer docs [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Documentation is provided in version control with the code [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Documentation is available online in a readable form [[8](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+
+3. Testing
+- [ ] Package has unit tests of individual components (e.g. functions, classes) [[9](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Package has integration tests that test the interaction between components that covers most of the code [[9](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Testing coverage is measured [[9](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+
+4. Software Maturity
+- [ ] All code is organized and provided as part of installable Python packages [[1](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Project has consistent and stable releases [[3](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Project releases are available through [PyPI](https://pypi.org) and [Conda](https://docs.conda.io/en/latest/) [[3](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Unstable code has a release number less than 1.0 (e.g. 0.x) [[3](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Project supports all major operating systems (MacOS, Linux, Windows) [[4](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] All code uses version control [[6](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Projects adopts the basic style recommendations of [PEP 8](https://www.python.org/dev/peps/pep-0008/) [[7](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Project imports the minimum number of packages necessary [[10](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Binary files are added to the package repository only when necessary [[14](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+
+5. Python 3
+- [ ] Package is compatible with python 3 [[11](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+
+6. License
+- [ ] Project has a license [[5](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]
+- [ ] Project has a permissive license for open source scientific software [[5](https://github.com/heliophysicsPy/standards/blob/master/standards.md#standards)]


### PR DESCRIPTION
This closes #95. We've been using that GitHub issue for a while as a temporary holding place for a draft of this template. I finalized the draft a couple months ago and it's ready to join this repo. I'm putting it in with the other similar markdown files (both of which are referenced in this template).

You can see it rendered here while the feature branch exists: https://github.com/heliophysicsPy/heliophysicsPy.github.io/blob/shawn-package-review-template/_pyhc_projects/package_review_template.md
