### PR TITLE
modifying instructions on how to join mailing list

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -7,7 +7,7 @@ order: 6
 ## Mailing List
 There is a Google Groups mailing list for discussions open to anyone. To be added to the mailing list for this project, please do the following:<br />
 1) Send an email to pyhc-list+subscribe@googlegroups.com. It doesn't have to have any subject/body text.  
-2) Shortly thereafter (generally, less than a minute), you'll get a reply from the pyhc subscribe list. Just hit reply and send. Again, no subject/body text is required.  
+2) Shortly thereafter (generally, less than a minute), you'll get a reply from the PyHC subscribe list. Just hit reply and send. Again, no subject/body text is required.  
 3) Shortly thereafter again, you should receive an email saying you have joined the pyhc-list Google Group.  
 
 Once you've joined, you will be able to send emails to the group via [pyhc-list@googlegroups.com](mailto: pyhc-list@googlegroups.com), from the email you used to join.<br />

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -6,15 +6,12 @@ order: 6
 ---
 ## Mailing List
 There is a Google Groups mailing list for discussions open to anyone. To be added to the mailing list for this project, please do the following:<br />
-1) Use the following link to add yourself to the mailing list [this link](https://groups.google.com/group/pyhc-list/subscribe).* <br />
-2) You should receive a follow up email to confirm your email.\** In that email, click 'Join This Group' to confirm your subscription. It should then send you back to the Google Groups page, with a message saying your email has been added to the groups.<br />
+1) Send an email to pyhc-list+subscribe@googlegroups.com. It doesn't have to have any subject/body text.  
+2) Shortly thereafter (generally, less than a minute), you'll get a reply from the pyhc subscribe list. Just hit reply and send. Again, no subject/body text is required.  
+3) Shortly thereafter again, you should receive an email saying you have joined the pyhc-list Google Group.  
 
-Once you've joined, you should be able to send emails to the group via [pyhc-list@googlegroups.com](mailto: pyhc-list@googlegroups.com)<br />
+Once you've joined, you will be able to send emails to the group via [pyhc-list@googlegroups.com](mailto: pyhc-list@googlegroups.com), from the email you used to join.<br />
 If the above steps do not work for you, please contact Julie Barnum at LASP, [Julie.Barnum@lasp.colorado.edu](mailto:Julie.Barnum@lasp.colorado.edu)
-
-\* Note, if you have a Google account and are logged into it on the tab in which you open the aforementioned link, there will not be an option for you to enter an email address when you go to the link, but rather it will assume you want to sign in with the email associated with your Google account and will pull up that information. If this is not your wish, just log out of your Google account, refresh the link, enter an email address, and make sure to confirm in the follow up email that is sent out after you enter your email address in the link.
-
-\** You will only receive a follow up opt-in email if you are not signed into a Google account when you click on the link to join the group. If you were signed into a Google account when you clicked on the link, and asked to join the group via the dialog box that pops up in that scenario, then whatever email address is associated with that Google account is added to the list with no needed follow up opt-in email.  
 
 ## Chat room
 For more informal discussions and questions there is a chat room to enable live chat between users and developers. The chat is hosted on matrix and clicking the following [link](https://riot.im/app/#/room/#heliopython:openastronomy.org) will open a browser window with the chat interface. There is no need to install any software.


### PR DESCRIPTION
The old method for some reason stopped working as it used to... instead of getting to the request to join page, you ended up at a page that showed all the pyhc list emails, but no option to join anywhere. Found a different way that people can join the list, which is also much simpler than the old method. Silver lining.