### PR TITLE
Updated apexpy testing badge

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -353,7 +353,7 @@
   keywords: ["ionosphere_thermosphere_mesosphere","specific"]
   community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Paritally met"]
+  testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]


### PR DESCRIPTION
The latest apexpy release (1.1.0) fixed the existing issues with integration testing.  The coverage is now at a level that may be considered "good".