### PR TITLE
Adding past biannual meeting DOIs to the website

### DIFF
--- a/_pages/docs.html
+++ b/_pages/docs.html
@@ -22,11 +22,12 @@ order: 2
 
   <div class="container mb-2">
     <div class="media">
-      <a href="https://zenodo.org/record/2537188#.XOXWVC2ZN24"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <a href="{{ site.baseurl }}/docs/meeting_reports/"><i class="fas fa-book fa-2x mr-3"></i></a>
       <div class="media-body">
-        <h5 class="mt-0">2018 PyHC Meeting Report</h5>
-        The official meeting report from the 2018 community meeting.<br>
-        <a href="https://doi.org/10.5281/zenodo.2537188"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.2537188.svg" alt="DOI"></a>
+        <h5 class="mt-0">
+          <a href="{{ site.baseurl }}/docs/meeting_reports/">PyHC Biannual Meeting Reports</a>
+        </h5>
+        PyHC biannual meeting reports summarizing meeting details (i.e. participant list, meeting summary and final agenda, conclusions, and future considerations).<br>
       </div>
     </div>
   </div>

--- a/_pages/docs.html
+++ b/_pages/docs.html
@@ -27,7 +27,7 @@ order: 2
         <h5 class="mt-0">
           <a href="{{ site.baseurl }}/docs/meeting_reports/">PyHC Biannual Meeting Reports</a>
         </h5>
-        PyHC biannual meeting reports summarizing meeting details (i.e. participant list, meeting summary and final agenda, conclusions, and future considerations).<br>
+        PyHC biannual meeting reports summarizing meeting details (e.g. participant list, meeting summary and final agenda, conclusions, and future considerations).<br>
       </div>
     </div>
   </div>

--- a/_pages/docs/meeting_reports.md
+++ b/_pages/docs/meeting_reports.md
@@ -1,0 +1,73 @@
+---
+layout: page
+title: PyHC Biannual Meeting Reports
+permalink: /docs/meeting_reports/
+exclude: true
+---
+
+This page contains all meeting reports on from biannual meetings held by the Python in Heliophysics Community. Click a link below to view the meeting report.
+
+  <div class="container mb-2">
+    <div class="media">
+      <a href="https://zenodo.org/record/2537188#.XOXWVC2ZN24"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">2018 PyHC Fall Meeting Report</h5>
+        The official meeting report from the Fall 2018 community meeting.<br>
+        <a href="https://doi.org/10.5281/zenodo.2537188"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.2537188.svg" alt="DOI"></a>
+      </div>
+    </div>
+  </div>
+
+  <br>
+
+  <div class="container mb-2">
+    <div class="media">
+      <a href="https://zenodo.org/record/4728159#.YIsZxpNKhTY"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">2019 PyHC Spring Meeting Report</h5>
+        The official meeting report from the Spring 2019 community meeting.<br>
+        <a href="https://doi.org/10.5281/zenodo.4728159"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4728159.svg" alt="DOI"></a>
+      </div>
+    </div>
+  </div>
+
+  <br>
+
+  <div class="container mb-2">
+    <div class="media">
+      <a href="https://zenodo.org/record/4728161#.YIsaF5NKhTY"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">2019 PyHC Fall Meeting Report</h5>
+        The official meeting report from the Fall 2019 community meeting.<br>
+        <a href="https://doi.org/10.5281/zenodo.4728161"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4728161.svg" alt="DOI"></a>
+      </div>
+    </div>
+  </div>
+
+  <br>
+
+  <div class="container mb-2">
+    <div class="media">
+      <a href="https://zenodo.org/record/4728184#.YIsaM5NKhTY"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">2020 PyHC Spring Meeting Report</h5>
+        The official meeting report from the Spring 2020 community meeting.<br>
+        <a href="https://doi.org/10.5281/zenodo.4728184"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4728184.svg" alt="DOI"></a>
+      </div>
+    </div>
+  </div>
+
+  <br>
+
+  <div class="container mb-2">
+    <div class="media">
+      <a href="https://zenodo.org/record/4728178#.YIsaSJNKhTY"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">2020 PyHC Fall Meeting Report</h5>
+        The official meeting report from the Fall 2020 community meeting.<br>
+        <a href="https://doi.org/10.5281/zenodo.4728178"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4728178.svg" alt="DOI"></a>
+      </div>
+    </div>
+  </div>
+
+  <br>


### PR DESCRIPTION
Closes #165 .

I created a new sub page that houses biannual meeting reports, and modified the documents page to point to this new sub page. Question to consider - if we have Zenodo links for all meeting reports, do we still want to link to the meeting reports stored in the G-Drive (on our Meetings page)? Or, do we want to point people to our Documents page for all meeting reports? 