### PR TITLE
Add link to Day 1 Zoom recording

### DIFF
--- a/_pages/meetings/spring2021.md
+++ b/_pages/meetings/spring2021.md
@@ -22,6 +22,11 @@ Materials associated with the meeting sessions will be kept in the [**meeting fo
  - [Hackathon projects](https://docs.google.com/spreadsheets/d/1EUqKfj6iAEPj2AQsyeNyo03qlbCFL0jNoygja4N6KtQ/edit#gid=0)
  - [Presentation and Tutorials Organizing](https://docs.google.com/spreadsheets/d/1JKoWtBTkwsackg_DbFFb3EXHXNDko0mmBBTu9cc2A2g/edit#gid=0)
 
+#### Meeting Recordings
+
+ - [Watch Day 1 here](https://cuboulder.zoom.us/rec/share/fP-LpSikrHRYGEeJ-g9BMXLpZ78h67gSHy6iXvR937lE8OpQV07HoyD15mC1O-gD.Wif-UdiYIK8FU3PR) 
+   - Passcode: !Y3G5xL9
+
 ### Zoom Meeting Information
 
 Join Zoom Meeting


### PR DESCRIPTION
I don't think we ever talked about how we'd actually share these Zoom recordings. I don't remember any such discussion at least.

This is my first idea for how to share them. I figure later we can download the recording files and upload them to Drive for posterity. For now, while the links are active, I like Zoom's interface for watching the recordings.

Welcome to feedback about this approach (e.g. it feels kinda silly to put a passcode on a public website). If you think we should share these in a different way, I'm all ears.