### PR TITLE
Update meetings page, add calendar link to home page

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -14,14 +14,13 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 
 ### Community Meetings
 
-The [2021 Spring Python in Heliophysics Community Meeting]({% link
-_pages/meetings/spring2021.md %}) **will be held remotely** on Zoom (see details on the meeting's web page), spanning over the course of four days. The meeting will begin on Monday, May 10th, 2021 and end Thursday, May 13th, 2021.
-* [Registration](https://docs.google.com/forms/d/1tk9uQTm9TzwNV8jle3QCg8IZkhZsQjLKMQDN-02a4IY/edit?usp=sharing)
+[2021 Spring Python in Heliophysics Community Meeting]({% link
+_pages/meetings/spring2021.md %}), May 10–13 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/1HcIQRnVmEXiTgNVx7cVL5mMySxVbUFYc)
 * [Meeting Report](https://docs.google.com/document/d/1G6Gr569NQ_j5FrW3fQkN-QtKazNznsDfHg39SOvnqSc/edit?usp=sharing)
 
 [2020 Fall Python in Heliophysics Community Meeting]({% link
-_pages/meetings/fall2020.md %}), October 26-November 16 (remote).
+_pages/meetings/fall2020.md %}), October 26–November 16 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/1T3CGRwXAst8jd7I6xFiKxyCgluGGpg0A)
 * [Meeting Report](https://docs.google.com/document/d/1roGSs_DKtXP5uLyPEHZrtA6taHW9zcMp0L54JKpg1p0/edit#heading=h.mpebd2k6hb5s)
 
@@ -30,14 +29,14 @@ _pages/meetings/april2020.md %}), April 29 (remote).
 * [Presentations and Documents](https://drive.google.com/drive/u/0/folders/1vONfB6hf0y-VVOPj1748R3U9agFyq0iV)
 * [Meeting Report](https://docs.google.com/document/d/1FqR3u4nP4HtH6baIYyzehMeDDo6Qp5ivKtduPmHETFY/edit)
 
-2019 Fall Python in Heliophysics Community Meeting, November 4-6, 2019 (at LASP).
+2019 Fall Python in Heliophysics Community Meeting, November 4–6, 2019 (at LASP).
 * [Presentations and Documents](https://drive.google.com/drive/u/0/folders/1lSM0DwLuKli1Rv9eKYe0vBVB_V8_9wKB)
 * [Meeting Report](https://docs.google.com/document/d/187QNQuN_OWmM9jS9lZGjSQpUIIiCaCDtBHiw4DAqSmY/edit#heading=h.wk29adekc64s)
 
-2019 Spring Python in Heliophysics Community Meeting, May 21-23, 2019 (at LASP). 
+2019 Spring Python in Heliophysics Community Meeting, May 21–23, 2019 (at LASP). 
 * [Meeting materials](https://drive.google.com/drive/u/0/folders/171Ba3Mq3MIaEXoc9X91gZhaXHVjoJde2)
 
-2018 Python in Heliophysics Working Group Meeting, November 13-15, 2018 (at LASP). 
+2018 Python in Heliophysics Working Group Meeting, November 13–15, 2018 (at LASP). 
 * [Meeting Report](https://docs.google.com/document/d/1ejP0kaibf6DRxjYJNmPrF1t3Nl21r0pC1FuDhu0hPnM/edit?usp=sharing)
 * [Presentations and Documents](https://drive.google.com/open?id=1snib9D8PcSaPByMqrAx8_4b05RfsTh58)
 * [Python in Heliophysics Community (PyHC) Standards](https://github.com/heliophysicsPy/standards/blob/main/standards.md)

--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@ permalink: /
     <li>Enable efficient interdisciplinary research</li>
 </ul>
 <br>
+<h2 class="text-center">Calendar</h2>
+<p class="text-center">
+Meetings and telecon times are available as a <a href="https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)">Google calendar</a>.
+</p>
 <h2>News</h2>
 <hr>
 {% for post in site.posts  limit:5 %}


### PR DESCRIPTION
Quick PR to correct the meetings page now that the Spring 2021 Meeting is over. 

I also saw an opportunity to paste the sentence we have about our Google Calendar on the home page. That starts to address Aaron's complaints about that stuff not being easy to find.