### PR TITLE
Add MCALF

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -459,3 +459,16 @@
   software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
+- name: "MCALF"
+  description: "Accurately constraining velocity information from spectral imaging observations using machine learning techniques."
+  docs: "https://mcalf.macbride.me/"
+  code: "https://github.com/ConorMacBride/mcalf"
+  contact: "Conor MacBride"
+  keywords: ["solar", "machine_learning", "spectra", "plotting", "line_plots", "2D_graphics", "multidimensional", "specific", "fits", "local", "data_analysis"]
+  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]


### PR DESCRIPTION
# MCALF: Multi-Component Atmospheric Line Fitting

*MCALF is an open-source Python package for accurately constraining velocity information from spectral imaging observations using machine learning techniques.*

This software package is intended to be used by solar physicists trying to extract line-of-sight (LOS) Doppler velocity information from spectral imaging observations (Stokes I measurements) of the Sun, especially observations where individual spectra can contain multiple spectral components. A ‘toolkit’ is provided that can be used to define a spectral model optimised for a particular dataset.

**I have labelled all of the PyHC standards as "Good".**