### PR TITLE
Create Fall 2021 meeting page

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -14,6 +14,11 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 
 ### Community Meetings
 
+[2021 Fall Python in Heliophysics Community Meeting]({% link
+_pages/meetings/spring2021.md %}), October 25–28 (remote).
+* [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1R81Q0gH09IV41sU9HUZGQWDwJ2YXa78Q?usp=sharing)
+* Meeting Report (check back here after the meeting)
+
 [2021 Spring Python in Heliophysics Community Meeting]({% link
 _pages/meetings/spring2021.md %}), May 10–13 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/1HcIQRnVmEXiTgNVx7cVL5mMySxVbUFYc)

--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -15,7 +15,7 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 ### Community Meetings
 
 [2021 Fall Python in Heliophysics Community Meeting]({% link
-_pages/meetings/spring2021.md %}), October 25–28 (remote).
+_pages/meetings/fall2021.md %}), October 25–28 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1R81Q0gH09IV41sU9HUZGQWDwJ2YXa78Q?usp=sharing)
 * Meeting Report (check back here after the meeting)
 

--- a/_pages/meetings/fall2021.md
+++ b/_pages/meetings/fall2021.md
@@ -8,8 +8,12 @@ exclude: true
 The fall 2021 meeting of the [Python in Heliophysics Community](http://heliopython.org) will be held remotely [**at this Zoom link**](https://cuboulder.zoom.us/j/97372369069) (Meeting ID: **973 7236 9069**). _The Zoom sessions will be recorded._ It will be spread across four sessions, starting Monday, October 25th, 2021 and ending Thursday, October 28th, 2021:
 
  - **Presentations:** October 25th 9:00 AM–11:00 AM (MT)
+   - HDEE project wrap-up/update presentations
  - **Tutorials/Presentations:** October 26th 9:00 AM–11:00 AM (MT)
+   - Core projects present ways their package could work nicely with other packages (e.g. as part of a tutorial, to accomplish a goal, to create new features)
+   - Tutorial brainstorming
  - **Hackathons:** October 27th 9:00 AM–11:00 AM (MT)
+   - Tutorial development
  - **Discussions:** October 28th 9:00 AM–11:00 AM (MT)
 
 See [the full agenda](https://docs.google.com/spreadsheets/d/19zVGD72ZFPrKS-o2DYjrBVAHtEY8EKEkFGjYa21XQgU/edit?usp=sharing) for exact dates/times of the various sessions. 

--- a/_pages/meetings/fall2021.md
+++ b/_pages/meetings/fall2021.md
@@ -32,39 +32,39 @@ Join Zoom Meeting
 [https://cuboulder.zoom.us/j/97372369069](https://cuboulder.zoom.us/j/97372369069)
 
 Meeting ID: **973 7236 9069**
+
 One tap mobile
-+16699006833,,97372369069# US (San Jose)
-+12532158782,,97372369069# US (Tacoma)
+ - +16699006833,,97372369069# US (San Jose)
+ - +12532158782,,97372369069# US (Tacoma)
 
 Dial by your location
-+1 669 900 6833 US (San Jose)
-+1 253 215 8782 US (Tacoma)
-+1 346 248 7799 US (Houston)
-+1 646 558 8656 US (New York)
-+1 301 715 8592 US (Washington DC)
-+1 312 626 6799 US (Chicago)
-Meeting ID: **973 7236 9069**
+ - +1 669 900 6833 US (San Jose)
+ - +1 646 558 8656 US (New York)
+
+Meeting ID: **973 7236 9069
+
 Find your local number: https://cuboulder.zoom.us/u/ay0zUdDFb
 
 Join by SIP
-97372369069@zoomcrc.com
+ - 97372369069@zoomcrc.com
 
 Join by H.323
-162.255.37.11 (US West)
-162.255.36.11 (US East)
-115.114.131.7 (India Mumbai)
-115.114.115.7 (India Hyderabad)
-213.19.144.110 (Amsterdam Netherlands)
-213.244.140.110 (Germany)
-103.122.166.55 (Australia Sydney)
-103.122.167.55 (Australia Melbourne)
-149.137.40.110 (Singapore)
-64.211.144.160 (Brazil)
-149.137.68.253 (Mexico)
-69.174.57.160 (Canada Toronto)
-65.39.152.160 (Canada Vancouver)
-207.226.132.110 (Japan Tokyo)
-149.137.24.110 (Japan Osaka)
+ - 162.255.37.11 (US West)
+ - 162.255.36.11 (US East)
+ - 115.114.131.7 (India Mumbai)
+ - 115.114.115.7 (India Hyderabad)
+ - 213.19.144.110 (Amsterdam Netherlands)
+ - 213.244.140.110 (Germany)
+ - 103.122.166.55 (Australia Sydney)
+ - 103.122.167.55 (Australia Melbourne)
+ - 149.137.40.110 (Singapore)
+ - 64.211.144.160 (Brazil)
+ - 149.137.68.253 (Mexico)
+ - 69.174.57.160 (Canada Toronto)
+ - 65.39.152.160 (Canada Vancouver)
+ - 207.226.132.110 (Japan Tokyo)
+ - 149.137.24.110 (Japan Osaka)
+ 
 Meeting ID: **973 7236 9069**
 
 ### Registration

--- a/_pages/meetings/fall2021.md
+++ b/_pages/meetings/fall2021.md
@@ -1,0 +1,72 @@
+---
+layout: page
+title: 2021 Fall Python in Heliophysics Community Meeting
+permalink: /meetings/fall2021/
+exclude: true
+---
+
+The fall 2021 meeting of the [Python in Heliophysics Community](http://heliopython.org) will be held remotely [**at this Zoom link**](https://cuboulder.zoom.us/j/97372369069) (Meeting ID: **973 7236 9069**). _The Zoom sessions will be recorded._ It will be spread across four sessions, starting Monday, October 25th, 2021 and ending Thursday, October 28th, 2021:
+
+ - **Presentations:** October 25th 9:00 AM–11:00 AM (MT)
+ - **Tutorials/Presentations:** October 26th 9:00 AM–11:00 AM (MT)
+ - **Hackathons:** October 27th 9:00 AM–11:00 AM (MT)
+ - **Discussions:** October 28th 9:00 AM–11:00 AM (MT)
+
+See [the full agenda](https://docs.google.com/spreadsheets/d/19zVGD72ZFPrKS-o2DYjrBVAHtEY8EKEkFGjYa21XQgU/edit?usp=sharing) for exact dates/times of the various sessions. 
+
+### Session Documents and Presentations
+
+Materials associated with the meeting sessions will be kept in the [**meeting folder**](https://drive.google.com/drive/folders/1R81Q0gH09IV41sU9HUZGQWDwJ2YXa78Q?usp=sharing) on Google Drive.
+
+ - [Meeting schedule](https://docs.google.com/spreadsheets/d/19zVGD72ZFPrKS-o2DYjrBVAHtEY8EKEkFGjYa21XQgU/edit?usp=sharing) (subject to change)
+ - [Hackathon projects](https://docs.google.com/spreadsheets/d/1sH56PhoabRuAnC5lY7SdR0erNYgGPZooYRaKRQhuIOY/edit?usp=sharing)
+ - [Presentation and Tutorials Organizing](https://docs.google.com/spreadsheets/d/1RjtwiHizFQd4FYONaV8ih7igGcNWFU5u24k_xEJciOk/edit?usp=sharing)
+
+#### Meeting Recordings
+
+ - (Check back here after the meeting)
+
+### Zoom Meeting Information
+
+Join Zoom Meeting
+[https://cuboulder.zoom.us/j/97372369069](https://cuboulder.zoom.us/j/97372369069)
+
+Meeting ID: **973 7236 9069**
+One tap mobile
++16699006833,,97372369069# US (San Jose)
++12532158782,,97372369069# US (Tacoma)
+
+Dial by your location
++1 669 900 6833 US (San Jose)
++1 253 215 8782 US (Tacoma)
++1 346 248 7799 US (Houston)
++1 646 558 8656 US (New York)
++1 301 715 8592 US (Washington DC)
++1 312 626 6799 US (Chicago)
+Meeting ID: **973 7236 9069**
+Find your local number: https://cuboulder.zoom.us/u/ay0zUdDFb
+
+Join by SIP
+97372369069@zoomcrc.com
+
+Join by H.323
+162.255.37.11 (US West)
+162.255.36.11 (US East)
+115.114.131.7 (India Mumbai)
+115.114.115.7 (India Hyderabad)
+213.19.144.110 (Amsterdam Netherlands)
+213.244.140.110 (Germany)
+103.122.166.55 (Australia Sydney)
+103.122.167.55 (Australia Melbourne)
+149.137.40.110 (Singapore)
+64.211.144.160 (Brazil)
+149.137.68.253 (Mexico)
+69.174.57.160 (Canada Toronto)
+65.39.152.160 (Canada Vancouver)
+207.226.132.110 (Japan Tokyo)
+149.137.24.110 (Japan Osaka)
+Meeting ID: **973 7236 9069**
+
+### Registration
+
+Please [**register**](https://forms.gle/dchiQzPHkcjf3SUQ7) by close of business Friday October 22nd, 2021 if you plan to participate remotely so that you may receive email announcements and updates.  No registration fee is required.  You may still participate without registering.

--- a/_pages/meetings/fall2021.md
+++ b/_pages/meetings/fall2021.md
@@ -41,7 +41,7 @@ Dial by your location
  - +1 669 900 6833 US (San Jose)
  - +1 646 558 8656 US (New York)
 
-Meeting ID: **973 7236 9069
+Meeting ID: **973 7236 9069**
 
 Find your local number: https://cuboulder.zoom.us/u/ay0zUdDFb
 
@@ -64,7 +64,7 @@ Join by H.323
  - 65.39.152.160 (Canada Vancouver)
  - 207.226.132.110 (Japan Tokyo)
  - 149.137.24.110 (Japan Osaka)
- 
+
 Meeting ID: **973 7236 9069**
 
 ### Registration

--- a/_posts/2021-08-09-fall-2021-meeting-announced.markdown
+++ b/_posts/2021-08-09-fall-2021-meeting-announced.markdown
@@ -8,7 +8,8 @@ PyHC serves as a community knowledge base for performing heliophysics research i
 
 **PyHC's second meeting of 2021 will be held remotely on Zoom. The meeting will run Monday, October 25th, 2021 - Thursday, October 28th, 2021, from 9 AM - 11 AM MT each day.** _The Zoom sessions will be recorded._ We’ll hold tutorial, hackathon, and project update sessions, as well as a couple other discussions that are relevant to the community. See [the full agenda](https://docs.google.com/spreadsheets/d/19zVGD72ZFPrKS-o2DYjrBVAHtEY8EKEkFGjYa21XQgU/edit?usp=sharing) for dates/times of the various sessions. Note that the agenda is subject to change. 
 
-The meeting's web page will be created shortly (and the link will be put here). **Registration, which is free but required, can be found [here](https://forms.gle/dchiQzPHkcjf3SUQ7).** The meeting's web page also has a link to registration, as well as the Zoom telecon information. If you’d like to join our mailing list to learn more information about the meeting and other upcoming events, please see the [PyHC Contact page](http://heliopython.org/contact/) for instructions. We also have an [Element chat group]( https://riot.im/app/#/room/#heliopython:openastronomy.org
+The meeting's web page can be found [here]({% link
+_pages/meetings/fall2021.md %}). **Registration, which is free but required, can be found [here](https://forms.gle/dchiQzPHkcjf3SUQ7).** The meeting's web page also has a link to registration, as well as the Zoom telecon information. If you’d like to join our mailing list to learn more information about the meeting and other upcoming events, please see the [PyHC Contact page](http://heliopython.org/contact/) for instructions. We also have an [Element chat group]( https://riot.im/app/#/room/#heliopython:openastronomy.org
 ) where we discuss various PyHC issues/topics, as well as discussing other Python-related questions.
 
 **Registration Deadline: COB, Friday, October 22nd, 2021.**  


### PR DESCRIPTION
This PR adds a Fall 2021 meeting page and links to it in the blog post. The format was based off the Spring 2021 page. I got the info/links from the Google Drive, but @jibarnum please make sure everything is accurate.