### PR TITLE
Remove heliopy

### DIFF
--- a/_data/projects_core.yml
+++ b/_data/projects_core.yml
@@ -13,22 +13,6 @@
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
-- name: "HelioPy"
-  website: https://heliopy.org
-  description: "A python library for heliospheric physics."
-  logo: "https://raw.githubusercontent.com/heliopython/heliopy/master/artwork/logo_circle.png"
-  docs: "http://docs.heliopy.org/en/stable/"
-  code: "https://github.com/heliopython/heliopy"
-  contact: "David Stansby"
-  keywords: ["solar","heliosphere","general"]
-  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-
-
 - name: "pysat"
   description: "Management and analysis tool for satellite and radar data."
   logo: "https://github.com/pysat/pysat/raw/main/logo.png"


### PR DESCRIPTION
I have plans to deprecate the entirity of `heliopy` in the near future (more at the PyHC meeting next week...), so it would be prudent to remove it from the core projects list.