### PR TITLE
Adding fall 2021 meeting report links

### DIFF
--- a/_pages/docs/meeting_reports.md
+++ b/_pages/docs/meeting_reports.md
@@ -84,3 +84,16 @@ This page contains all meeting reports on from biannual meetings held by the Pyt
   </div>
 
   <br>
+
+  <div class="container mb-2">
+    <div class="media">
+      <a href="https://zenodo.org/record/5745358#.YaZxM_FKhTY"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">2021 PyHC Fall Meeting Report</h5>
+        The official meeting report from the Fall 2021 community meeting.<br>
+        <a href="https://doi.org/10.5281/zenodo.5745358"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5745358.svg" alt="DOI"></a>
+      </div>
+    </div>
+  </div>
+
+  <br>

--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -17,7 +17,7 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 [2021 Fall Python in Heliophysics Community Meeting]({% link
 _pages/meetings/fall2021.md %}), October 25–28 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1R81Q0gH09IV41sU9HUZGQWDwJ2YXa78Q?usp=sharing)
-* Meeting Report (check back here after the meeting)
+* [Meeting Report](https://docs.google.com/document/d/1wS0LQSaq7GWGJJkmcUzBAZHdEUADQahwazSvkR37QGI/edit?usp=sharing)
 
 [2021 Spring Python in Heliophysics Community Meeting]({% link
 _pages/meetings/spring2021.md %}), May 10–13 (remote).


### PR DESCRIPTION
I created a meeting report for the Fall 2021 meeting on Google Drive and put it on Zenodo. Adding links to all that here.