### PR TITLE
Add Python Resources

### DIFF
--- a/_pages/docs.html
+++ b/_pages/docs.html
@@ -50,6 +50,20 @@ order: 2
 
   <div class="container mb-2">
     <div class="media">
+      <a href="{{ site.baseurl }}/docs/python_resources/"><i class="fas fa-book fa-2x mr-3"></i></a>
+      <div class="media-body">
+        <h5 class="mt-0">
+          <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a>
+        </h5>
+        Resources for getting started with Python.<br>
+      </div>
+    </div>
+  </div>
+
+  <br>
+
+  <div class="container mb-2">
+    <div class="media">
       <a href="{{ site.baseurl }}/docs/suggested_tools/"><i class="fas fa-book fa-2x mr-3"></i></a>
       <div class="media-body">
         <h5 class="mt-0">

--- a/_pages/docs/python_resources.md
+++ b/_pages/docs/python_resources.md
@@ -31,7 +31,7 @@ The Jupyter Notebook is a web application that allows you to create and share do
 ### SciPy 2019 Presentations
 SciPy 2019 was the 18th annual Scientific Computing with Python conference. Follow these links to watch a selection of helpful presentations from it. Note that we picked 2019 because there was an in-person element.
 
- - [2 Hour Introduction to Python](https://www.youtube.com/watch?v=6KM8HOQi5Xk)
+ - [Two-Hour Introduction to Python](https://www.youtube.com/watch?v=6KM8HOQi5Xk)
 
  - [Getting Started with Jupyter](https://www.youtube.com/watch?v=RFabWieskak)
 

--- a/_pages/docs/python_resources.md
+++ b/_pages/docs/python_resources.md
@@ -4,33 +4,37 @@ title: Python Resources
 permalink: /docs/python_resources/
 exclude: true
 ---
-Here are some resources to help you get started if you are new to Python development.
+Below are some resources to help you get started if you are new to Python development.
 
 <br>
 
-### Web Resources
-Some helpful web pages:
+### Getting Started
+Python is an interpreted, dynamically-typed, high-level programming language. Its design philosophy emphasizes code readability with its use of significant indentation. Follow these links to familiarize yourself with the basics of the language.
 
- - For beginner Python material: [https://astg606.github.io/py_courses/beginner_python/](https://astg606.github.io/py_courses/beginner_python/)
+ - [Python Beginner Course for Programmers](https://astg606.github.io/py_courses/beginner_python/)
 
- - PlasmaPy's hackweek had some intro to Python materials here: [https://hack.plasmapy.org/2021/python/](https://hack.plasmapy.org/2021/python/)
+ - [PlasmaPy Hack Week's Prequel Python Tutorials](https://hack.plasmapy.org/2021/python/)
 
- - Another intro to Jupyter notebooks: [https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook](https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook)
-
- - Python's website: [https://www.python.org](https://www.python.org)
-
- - Jupyter's notebook website: [https://jupyter.org](https://jupyter.org)
+ - [Python's Own Introductory Material](https://www.python.org/about/gettingstarted/)
 
 <br>
 
-### Presentations
-Some helpful talks/presentations:
+### Jupyter Notebooks
+The Jupyter Notebook is a web application that allows you to create and share documents that combine live code, narrative text, visualizations, interactive dashboards, and other media. Notebooks are a popular way to write and share Python code. Follow these links to learn about them.
 
- - There should be some [good videos here](https://www.youtube.com/results?search_query=scipy+2019) from the scipy conference in Austin
+ - [The Definitive Guide to Jupyter Notebooks](https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook)
 
-   - 4hr Intro to Python: [https://www.youtube.com/watch?v=6KM8HOQi5Xk](https://www.youtube.com/watch?v=6KM8HOQi5Xk)
-   - Getting started with jupyter: [https://www.youtube.com/watch?v=RFabWieskak](https://www.youtube.com/watch?v=RFabWieskak)
-   - numpy intro: [https://www.youtube.com/watch?v=ZB7BZMhfPgk](https://www.youtube.com/watch?v=ZB7BZMhfPgk)
-   - pandas intro: [https://www.youtube.com/watch?v=5rNu16O3YNE](https://www.youtube.com/watch?v=5rNu16O3YNE)
+ - [Jupyter's Website](https://jupyter.org)
 
-   Note, we picked 2019 since there was an in-person element. Other years work as well.
+ <br>
+
+### SciPy 2019 Presentations
+SciPy 2019 was the 18th annual Scientific Computing with Python conference. Follow these links to watch a selection of helpful presentations from it. Note that we picked 2019 because there was an in-person element.
+
+ - [2 Hour Introduction to Python](https://www.youtube.com/watch?v=6KM8HOQi5Xk)
+
+ - [Getting Started with Jupyter](https://www.youtube.com/watch?v=RFabWieskak)
+
+ - [Introduction to Numerical Computing with NumPy](https://www.youtube.com/watch?v=ZB7BZMhfPgk)
+ 
+ - [Introduction to Data Processing with Pandas](https://www.youtube.com/watch?v=5rNu16O3YNE)

--- a/_pages/docs/python_resources.md
+++ b/_pages/docs/python_resources.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Python Resources
+permalink: /docs/python_resources/
+exclude: true
+---
+Here are some resources to help you get started if you are new to Python development.
+
+<br>
+
+### Web Resources
+Some helpful web pages:
+
+ - For beginner Python material: [https://astg606.github.io/py_courses/beginner_python/](https://astg606.github.io/py_courses/beginner_python/)
+
+ - PlasmaPy's hackweek had some intro to Python materials here: [https://hack.plasmapy.org/2021/python/](https://hack.plasmapy.org/2021/python/)
+
+ - Another intro to Jupyter notebooks: [https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook](https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook)
+
+ - Python's website: [https://www.python.org](https://www.python.org)
+
+ - Jupyter's notebook website: [https://jupyter.org](https://jupyter.org)
+
+<br>
+
+### Presentations
+Some helpful talks/presentations:
+
+ - There should be some [good videos here](https://www.youtube.com/results?search_query=scipy+2019) from the scipy conference in Austin
+
+   - 4hr Intro to Python: [https://www.youtube.com/watch?v=6KM8HOQi5Xk](https://www.youtube.com/watch?v=6KM8HOQi5Xk)
+   - Getting started with jupyter: [https://www.youtube.com/watch?v=RFabWieskak](https://www.youtube.com/watch?v=RFabWieskak)
+   - numpy intro: [https://www.youtube.com/watch?v=ZB7BZMhfPgk](https://www.youtube.com/watch?v=ZB7BZMhfPgk)
+   - pandas intro: [https://www.youtube.com/watch?v=5rNu16O3YNE](https://www.youtube.com/watch?v=5rNu16O3YNE)
+
+   Note, we picked 2019 since there was an in-person element. Other years work as well.

--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -64,5 +64,5 @@ _pages/meetings/april2020.md %}), April 29 (remote).
 
 #### Summer School
 
-* We are excited to announce our inaugural [2022 Summer School](https://heliopython.org/summer-school), in partnership with the European Space Astronomy Centre (ESAC)! [Click here for more info](https://heliopython.org/summer-school).
+* We are excited to announce our inaugural <a href="{{ site.baseurl }}/summer-school/">2022 Summer School</a>, in partnership with the European Space Astronomy Centre (ESAC)! <a href="{{ site.baseurl }}/summer-school/">Click here for more info</a>.
 

--- a/_pages/meetings/summer_school.md
+++ b/_pages/meetings/summer_school.md
@@ -38,6 +38,11 @@ The official language of the PyHC 2022 Summer School is English. Simultaneous in
 
 <br>
 
+### Python Resources
+You do not have to be a Python expert to attend. We will teach some Python best practices, but if you have no prior experience with Python, please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics.
+
+<br>
+
 ### Agenda
 (subject to small changes as we finalize it)
 #### Day 1: Monday, 30 May 2022

--- a/_pages/meetings/summer_school.md
+++ b/_pages/meetings/summer_school.md
@@ -39,7 +39,7 @@ The official language of the PyHC 2022 Summer School is English. Simultaneous in
 <br>
 
 ### Python Resources
-You do not have to be a Python expert to attend. We will teach important Python best practices, but please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics if you have no prior experience with Python or Jupyter Notebooks.
+You do not have to be a Python expert to attend. We will teach important Python best practices, but please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics if you have no prior experience with Python or Jupyter Notebooks, as those basics will not be taught.
 
 <br>
 

--- a/_pages/meetings/summer_school.md
+++ b/_pages/meetings/summer_school.md
@@ -39,7 +39,7 @@ The official language of the PyHC 2022 Summer School is English. Simultaneous in
 <br>
 
 ### Python Resources
-You do not have to be a Python expert to attend. We will teach some Python best practices, but please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics if you have no prior experience with Python. 
+You do not have to be a Python expert to attend. We will teach important Python best practices, but please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics if you have no prior experience with Python or Jupyter Notebooks.
 
 <br>
 

--- a/_pages/meetings/summer_school.md
+++ b/_pages/meetings/summer_school.md
@@ -39,7 +39,7 @@ The official language of the PyHC 2022 Summer School is English. Simultaneous in
 <br>
 
 ### Python Resources
-You do not have to be a Python expert to attend. We will teach some Python best practices, but if you have no prior experience with Python, please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics.
+You do not have to be a Python expert to attend. We will teach some Python best practices, but please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics if you have no prior experience with Python. 
 
 <br>
 


### PR DESCRIPTION
Closes #205.

This PR adds a new "Python Resources" page that lives under "Documents". I added a section to the summer school page that links to this new info. The links are those shared in issue #205. I figured they were a good enough starting point, and we can always add to/modify this page later if we find new material to share.

**Let me know if you like the general structure and how I worked it into the flow of the summer school page. Input on wording choices etc. are totally welcome.**



(Note, while I was in there, I also found a way to make the summer school links in the "Meetings" page relative to the site's base URL, which supports local development.)