### PR TITLE
Update hotel info, remote info, and agenda

### DIFF
--- a/_pages/meetings/summer_school.md
+++ b/_pages/meetings/summer_school.md
@@ -68,7 +68,7 @@ You do not have to be a Python expert to attend. We will teach important Python 
     - [https://docs.sunpy.org/en/stable/](https://docs.sunpy.org/en/stable/) 
 
 #### Day 2: Tuesday, 31 May 2022 
-**2 PM CEST / 12 PM UTC until 8:30 PM CEST / 6:30 UTC**
+**2 PM CEST / 12 PM UTC until 9 PM CEST / 7 PM UTC**
 
 **Focus: PlasmaPy + SpacePy**
  - Kicking off the day’s activities [15m]
@@ -97,7 +97,7 @@ You do not have to be a Python expert to attend. We will teach important Python 
  - _Group Dinner this night!_
 
 #### Day 4: Thursday, 02 June 2022
-**2 PM CEST / 12 PM UTC until 8:30 PM CEST / 6:30 UTC**
+**2 PM CEST / 12 PM UTC until 9 PM CEST / 7 PM UTC**
 
 **Focus: pySPEDAS + pysat**
  - Kicking off the day’s activities [15m]
@@ -110,7 +110,7 @@ You do not have to be a Python expert to attend. We will teach important Python 
     - [https://pysat.readthedocs.io/en/latest/](https://pysat.readthedocs.io/en/latest/)
 
 #### Day 5: Friday, 03 June 2022
-**2 PM CEST / 12 PM UTC until 8:30 PM CEST / 6:30 UTC**
+**2 PM CEST / 12 PM UTC until 9 PM CEST / 7 PM UTC**
 
 **Focus: Kamodo + Additional PyHC Packages + Python Learning Session + Wrap Up**
  - Kicking off the day’s activities [15m]

--- a/_pages/meetings/summer_school.md
+++ b/_pages/meetings/summer_school.md
@@ -7,7 +7,7 @@ exclude: true
 ---
 <img src="../../img/page_images/summer-school.jpg" alt="Summer School 30 May 2022 – Friday, 3 June 2022" style="display: block; margin-left: auto; margin-right: auto; width: 60%">
 
-The Python in Heliophysics Community (PyHC) is excited to announce its inaugural 2022 Summer School, in partnership with the European Space Astronomy Centre (ESAC)! The PyHC Summer School will take place Monday, **30 May 2022 – Friday, 3 June 2022** at ESAC in beautiful Madrid, Spain. There will also be remote participation options for those unable to attend in-person. **This event is free** and open to all graduate students, early career scientists, and established scientists looking to transition to Python in the Heliophysics and Space Weather disciplines. PyHC Summer School attendees will learn Python best practices and receive hands-on instruction from experts as they take a deep dive — via tutorials, demos, and presentations — into the rich ecosystem of Heliophysics Python packages. 
+The Python in Heliophysics Community (PyHC) is excited to announce its inaugural 2022 Summer School, in partnership with the European Space Astronomy Centre (ESAC)! The PyHC Summer School will take place Monday, **30 May 2022 – Friday, 3 June 2022** at ESAC in beautiful Madrid, Spain. There will also be remote participation options (e.g. Zoom) for those unable to attend in-person. **This event is free** and open to all graduate students, early career scientists, and established scientists looking to transition to Python in the Heliophysics and Space Weather disciplines. PyHC Summer School attendees will learn Python best practices and receive hands-on instruction from experts as they take a deep dive — via tutorials, demos, and presentations — into the rich ecosystem of Heliophysics Python packages. 
 
 <br>
 
@@ -29,10 +29,10 @@ Urbanización Villafranca del Castillo<br>
 Villanueva de la Cañada<br>
 E-28692 Madrid, Spain<br>
 
-(and online)
+(and online via Zoom, details TBA)
 
 #### Hotel
-We recommend staying at the [Leonardo Hotel Madrid City Center](https://www.leonardo-hotels.es/madrid/leonardo-hotel-madrid-city-center).
+We recommend booking a hotel near Plaza de España, as buses will transport attendees from Plaza de España to ESAC each day. A good option is the [Leonardo Hotel Madrid City Center](https://www.leonardo-hotels.es/madrid/leonardo-hotel-madrid-city-center).
 
 <br>
 
@@ -49,6 +49,8 @@ You do not have to be a Python expert to attend. We will teach important Python 
 ### Agenda
 (subject to small changes as we finalize it)
 #### Day 1: Monday, 30 May 2022
+**2 PM CEST / 12 PM UTC until 9 PM CEST / 7 PM UTC**
+
 **Focus: PyHC Introduction + AstroPy for Heliophysics + SunPy**
  - Introductions (welcome, agenda, code of conduct reminder, etc.) [15m]
  - Slide deck introducing PyHC [30m]
@@ -59,12 +61,15 @@ You do not have to be a Python expert to attend. We will teach important Python 
  - “AstroPy for Heliophysics” project introduction [2h45m; included 15m break halfway]
     - [https://github.com/astropy/astropy](https://github.com/astropy/astropy) 
     - [https://docs.astropy.org/en/stable/](https://docs.astropy.org/en/stable/) 
+    - Workshop materials available at: [https://github.com/astropy/astropy-workshop](https://github.com/astropy/astropy-workshop) 
  - Lunch break [45m]
  - SunPy project introduction [2h45m; included 15m break halfway]
     - [https://github.com/sunpy/sunpy](https://github.com/sunpy/sunpy )
     - [https://docs.sunpy.org/en/stable/](https://docs.sunpy.org/en/stable/) 
 
-#### Day 2: Tuesday, 31 May 2022
+#### Day 2: Tuesday, 31 May 2022 
+**2 PM CEST / 12 PM UTC until 8:30 PM CEST / 6:30 UTC**
+
 **Focus: PlasmaPy + SpacePy**
  - Kicking off the day’s activities [15m]
  - PlasmaPy project introduction [2h45m; included 15m break halfway]
@@ -76,16 +81,15 @@ You do not have to be a Python expert to attend. We will teach important Python 
     - [https://spacepy.github.io/](https://spacepy.github.io/) 
 
 #### Day 3: Wednesday, 01 June 2022
-**Focus: HAPI + Python Testing + Group Outing**
+**2 PM CEST / 12 PM UTC until 5:30 PM CEST / 3:30 PM UTC**
+
+**Focus: HAPI + Group Outing**
  - Kicking off the day’s activities [15m]
  - HAPI project introduction [3h15m; included 15m break halfway]
     - An intro for software-centric scientists who want to use HAPI data in their analyses 
     - A session for science-minded developers who want to serve HAPI data or incorporate it into their analyses
         - [https://github.com/hapi-server/client-python](https://github.com/hapi-server/client-python)
         - [http://hapi-server.org](http://hapi-server.org)
- - Python learning session: Testing [30m]
-    - Intro to testing in Python and best practices for testing
-        - Comprised of a pytest tutorial combined with a discussion on best practices for testing scientific software
  - End the day earlier
     - Transition to free time and/or planned activity
         - Trip to ESA/NASA deep space network station? (~30m from meeting site)
@@ -93,6 +97,8 @@ You do not have to be a Python expert to attend. We will teach important Python 
  - _Group Dinner this night!_
 
 #### Day 4: Thursday, 02 June 2022
+**2 PM CEST / 12 PM UTC until 8:30 PM CEST / 6:30 UTC**
+
 **Focus: pySPEDAS + pysat**
  - Kicking off the day’s activities [15m]
  - pySPEDAS project introduction [2h45m; included 15m break halfway]
@@ -104,16 +110,27 @@ You do not have to be a Python expert to attend. We will teach important Python 
     - [https://pysat.readthedocs.io/en/latest/](https://pysat.readthedocs.io/en/latest/)
 
 #### Day 5: Friday, 03 June 2022
-**Focus: Kamodo + Speasy + Configuring PyHC Software Locally + Wrap Up**
+**2 PM CEST / 12 PM UTC until 8:30 PM CEST / 6:30 UTC**
+
+**Focus: Kamodo + Additional PyHC Packages + Python Learning Session + Wrap Up**
  - Kicking off the day’s activities [15m]
  - Kamodo project introduction [2h45m; included 15m break halfway]
     - [https://github.com/nasa/Kamodo](https://github.com/nasa/Kamodo)
     - [https://ccmc.gsfc.nasa.gov/Kamodo/](https://ccmc.gsfc.nasa.gov/Kamodo/ ) 
- - Speasy (formally AmdaPy) project introduction [1h45m; included 15m break at end of session]
-    - [https://pypi.org/project/speasy/](https://pypi.org/project/speasy/), [https://github.com/SciQLop/speasy](https://github.com/SciQLop/speasy) 
-    - [https://speasy.readthedocs.io/en/stable/](https://speasy.readthedocs.io/en/stable/ )
- - Python learning session: Configuring and using PyHC packages locally [1h45m]
-    - Installing how to’s, basic commands, etc.
+ - Project Potpourri [1h45m; included 15m breaks between presentations] 
+    - Speasy (formally AmdaPy) project introduction [30m]
+       - [https://pypi.org/project/speasy/](https://pypi.org/project/speasy/), [https://github.com/SciQLop/speasy](https://github.com/SciQLop/speasy) 
+       - [https://speasy.readthedocs.io/en/stable/](https://speasy.readthedocs.io/en/stable/)
+    - OMMBV project introduction [30m]
+       - [https://github.com/rstoneback/OMMBV](https://github.com/rstoneback/OMMBV)
+       - [https://ommbv.readthedocs.io/en/latest/?badge=latest](https://ommbv.readthedocs.io/en/latest/?badge=latest)
+    - TBD [30m]
+ - Python learning session [1h45m]
+    - Configuring and using PyHC packages locally 
+       - Installing how to’s, basic commands, etc.
+    - Python testing
+       - Intro to testing in Python and best practices for testing
+       - Comprised of a pytest tutorial combined with a discussion on best practices for testing scientific software
  - Wrap up [30m]
     - Retrospective
     - Gather feedback from attendees — what did you like? Not like? What needed more/less time? What other topics do you hope to see in future summer schools? 


### PR DESCRIPTION
This PR:
- Mentions Zoom
- Updates hotel info
- Updates the agenda
    - Reflect the current agenda in Google Drive
    - Add times of day

Note about Zoom: I'll split up the "Location" section into "In-person" and "Remote" sections once we have Zoom info. But it looked silly to do that right now, hence I left Zoom TBA in parens.

Question to you, @jibarnum: our agenda in Google Drive says we'll be doing 2pm-9pm Madrid time each day (except Day 3 that ends early). Day 1 is the only day that actually adds up to 7 hours of material though (the other days add up to 6.5 hours). Am I correct to assume that's because we're intentionally giving ourselves a half hour of breathing room? Just making sure it's correct to put that those days end at 9pm, not 8:30pm.

Also, I was having trouble deciding where to put the times. I considered just writing once above the agenda that days go from 2pm-9pm. But because Day 3 is different, I tried putting times underneath each day's title. Which option do you like better? I'm not sure if what I have now is too repetitive.
