### PR TITLE
Add project solo-epd-loader

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -249,13 +249,26 @@
   description: Date / time conversions used in the sciences.
   contact: Michael Hirsch
   keywords: ["solar","magnetosphere","ionosphere_thermosphere_mesosphere","specific"]
+  
+- name: solo-epd-loader
+  code: https://github.com/jgieseler/solo-epd-loader
+  description: "Data loader for Solar Orbiter/EPD energetic charged particle sensors EPT, HET, and STEP"
+  docs: https://github.com/jgieseler/solo-epd-loader#readme=
+  contact: Jan Gieseler
+  keywords: ["data", "data_access", "data_retrieval", "heliosphere", "heliophysics", "instrumentation", "solar", "space physics", "specific"]
+  community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Requires%20improvement-red.svg", "Requires improvement"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
 - name: Speasy
   code: https://github.com/SciQLop/speasy
   description: "Retreive data from many space physics Web services"
   docs: https://speasy.readthedocs.io/
   contact: Alexis Jeandet
-  keyworrds: ["heliophysics", "space physics", "magnetospheric physics", "data_retrieval", "web_service", "remote", "data"]
+  keywords: ["heliophysics", "space physics", "magnetospheric physics", "data_retrieval", "web_service", "remote", "data"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]


### PR DESCRIPTION
**solo-epd-loader** is a small package whose only goal is to provide data of Solar Orbiter's Energetic Particle Detector (EPD). It downloads the data from ESA's [Solar Orbiter Archive (SOAR)](http://soar.esac.esa.int/soar) if needed. The functionality is partly available also in SunPy, but there only in a general way. In addition, here the aim is (in the future) to further process the data because some of the data products are not really final.

PyHC standards that are not _good_:
- **Community** ("Partially met"): Collaboration encouragement/guidelines missing.
- **Testing** ("Requires improvement"): Mostly missing and only done manually so far, but planned for the future. Shouldn't be too bad because the functionality is relatively small.