### PR TITLE
Add project solarmach

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -249,6 +249,19 @@
   description: Date / time conversions used in the sciences.
   contact: Michael Hirsch
   keywords: ["solar","magnetosphere","ionosphere_thermosphere_mesosphere","specific"]
+  
+- name: solarmach
+  code: https://github.com/jgieseler/solarmach
+  description: "Multi-spacecraft heliospheric configuration plotter"
+  docs: https://github.com/jgieseler/solarmach#readme=
+  contact: Jan Gieseler
+  keywords: ["solar", "heliosphere",  "coordinates", "2D_graphics", "plotting", "general", "web_service"]
+  community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Requires%20improvement-red.svg", "Requires improvement"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
 - name: solo-epd-loader
   code: https://github.com/jgieseler/solo-epd-loader

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -251,6 +251,7 @@
   keywords: ["solar","magnetosphere","ionosphere_thermosphere_mesosphere","specific"]
   
 - name: solarmach
+  url: "https://solar-mach.github.io"
   code: https://github.com/jgieseler/solarmach
   description: "Multi-spacecraft heliospheric configuration plotter"
   docs: https://github.com/jgieseler/solarmach#readme=


### PR DESCRIPTION
**solarmach** is a small package that provides a multi-spacecraft heliospheric configuration plotter to analyse the location and magnetic connection of the heliospheric spacecraft fleet at a given time. For this, it utilizes SunPy's get_horizons_coord() functionality to obtain spacecraft ephemeris from JPL HORIZONS, calculates the nominal (solar-wind-speed dependent) Parker heliospheric magnetic field lines, and visualize the results.

PyHC standards that are not _good_:
- **Community** ("Partially met"): Collaboration encouragement/guidelines missing.
- **Testing** ("Requires improvement"): Mostly missing and only done manually so far, but planned for the future. Shouldn't be too bad because the functionality is relatively small.