### PR TITLE
Display Google Calendar directly on website

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -12,7 +12,9 @@ Telecons are held approximately every two weeks on Mondays at 09:00 AM Mountain 
 
 ### Calendar
 
-Meetings and telecon times are available as a [Google calendar](https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+Meetings and telecon times are available as a [Google calendar](https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ):
+<br>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23f9e79f&ctz=America%2FDenver&showTitle=0&title=PyHC%20Events&showDate=1&showPrint=0&showTabs=1&showCalendars=0&showNav=1&src=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%237CB342" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 
 <br>
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,9 @@ permalink: /
 <br>
 <h2 class="text-center">Calendar</h2>
 <p class="text-center">
-PyHC meets in person twice yearly. Telecons are held approximately every two weeks on Mondays at 09:00 AM Mountain time, but this can fluctuate depending on holidays, conferences, etc. Meetings and telecon times are available on our <a href="https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Google Calendar</a>.
+PyHC meets in person twice yearly. Telecons are held approximately every two weeks on Mondays at 09:00 AM Mountain time, but this can fluctuate depending on holidays, conferences, etc. Meetings and telecon times are available on our <a href="https://calendar.google.com/calendar?cid=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Google Calendar</a>:
+<br><br>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23f9e79f&ctz=America%2FDenver&showTitle=0&title=PyHC%20Events&showDate=1&showPrint=0&showTabs=1&showCalendars=0&showNav=1&src=NG42Z3YyaWZncDZyZ25rOGF1N2pzZjF1azBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%237CB342" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 </p>
 <h2>News</h2>
 <hr>


### PR DESCRIPTION
This PR excites me. I found a way to display our Google Calendar directly on the website without people having to click any links nor sign into Google! 

I added the calendar to the "Calendar" sections of our homepage and Meetings page.

@jibarnum is your dev environment set up to run this repo locally with `bundle exec jekyll serve`? I've only tested this locally on my machine and it'd be good to make sure it works on others before we merge. But if not, we can always just merge anyway and "do it live."