### PR TITLE
Limit homepage blog posts to 3 instead of 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ PyHC meets in person twice yearly. Telecons are held approximately every two wee
 </p>
 <h2>News</h2>
 <hr>
-{% for post in site.posts  limit:5 %}
+{% for post in site.posts  limit:3 %}
 <h3><a href="{{ post.url | prepend: site.baseurl }}" class="nounderline">{{ post.title }}</a></h3>
 <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <time>{{ post.date | date: "%b %-d, %Y" }}{% if post.author %} • <a href="http://github.com/{{ post.author }}" target="_blank"><img src="https://github.com/{{ post.author }}.png?size=15"/></a> @{{ post.author }}{% endif %}{% if post.meta %} • {{ post.meta }}{% endif %}</time>
 {{ post.content | markdownify }}


### PR DESCRIPTION
Simple, self-explanatory change to show only 3 blog posts on the homepage rather than the current 5. 

This was the last homepage change I'd planned back when we were discussing how to improve the homepage. The two main requests were 1) better display telecon times and 2) remove focus on repetitive blog posts.

1) Was accomplished by displaying our Google Calendar directly on the website.
2) Is accomplished by this change—3 posts personally feels like a lot less to scroll past, and we're less likely to repeat ourselves in just the most recent 3 posts.