### PR TITLE
Create 2022 Fall Meeting page

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -20,6 +20,11 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 
 ### Community Meetings
 
+[2022 Fall Python in Heliophysics Community Meeting]({% link
+_pages/meetings/fall2022.md %}), November 7–10 (remote).
+* [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/193ekRMe7TlcSnrlWrxkyHwu45VlOwurX?usp=sharing)
+* Meeting Report (to be produced shortly after the Fall 2022 meeting ends)
+
 [2022 Spring Python in Heliophysics Community Meeting]({% link
 _pages/meetings/spring2022.md %}), May 16–19 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1CCI5OSGNFcJwzpzgxaQMo8_s_oRN9j1o?usp=sharing)

--- a/_pages/meetings/fall2022.md
+++ b/_pages/meetings/fall2022.md
@@ -1,0 +1,67 @@
+---
+layout: page
+title: 2022 Fall Python in Heliophysics Community Meeting
+permalink: /meetings/fall2022/
+exclude: true
+---
+
+The fall 2022 meeting of the [Python in Heliophysics Community](http://heliopython.org) will be held remotely [**at this Zoom link**](https://cuboulder.zoom.us/j/97372369069) (Meeting ID: **973 7236 9069**). _The Zoom sessions will be recorded._ It will be spread across four sessions, starting Monday, November 7th, 2022 and ending Thursday, November 10th, 2022:
+
+ - **Overview presentations:** November 7th 9:00 AM–11:00 AM (MT)
+ - **Project update presentations:** November 8th 9:00 AM–11:00 AM (MT)
+ - **Hackathons:** November 9th 9:00 AM–11:00 AM (MT)
+ - **Hackathon results and other discussions:** November 10th 9:00 AM–11:00 AM (MT)
+
+See [the full agenda](https://docs.google.com/spreadsheets/d/1vLrhzk_-hEfsZotOZypZtMPG6Vq1PvfP/edit#gid=1340464101) for exact dates/times of the various sessions.
+
+### Session Documents and Presentations
+
+Materials associated with the meeting sessions will be kept in the [**meeting folder**](https://drive.google.com/drive/u/0/folders/193ekRMe7TlcSnrlWrxkyHwu45VlOwurX) on Google Drive.
+
+ - [Meeting schedule](https://docs.google.com/spreadsheets/d/1vLrhzk_-hEfsZotOZypZtMPG6Vq1PvfP/edit#gid=1340464101) (subject to change)
+ - [Hackathon projects](https://docs.google.com/spreadsheets/d/1SZogJukReYqAVLt59WkdFzSznx5OetSv/edit?usp=sharing)
+ - [Presentation and Tutorials Organizing](https://docs.google.com/spreadsheets/d/1vLrhzk_-hEfsZotOZypZtMPG6Vq1PvfP/edit#gid=1340464101) (link may change)
+
+#### Meeting Recordings
+
+ - (Check back here after the meeting)
+
+### Zoom Meeting Information
+
+Join Zoom Meeting
+[**https://cuboulder.zoom.us/j/97372369069**](https://cuboulder.zoom.us/j/97372369069)
+
+Meeting ID: **973 7236 9069**
+
+One tap mobile
+ - +16699006833,,395871054# US (San Jose)
+ - +16465588656,,395871054# US (New York)
+
+Dial by your location
+ - +1 669 900 6833 US (San Jose)
+ - +1 646 558 8656 US (New York)
+
+Meeting ID: **973 7236 9069**
+
+Find your local number: https://cuboulder.zoom.us/u/ab3XRN96S2
+
+Join by SIP
+ - 395871054@zoomcrc.com
+
+Join by H.323
+ - 162.255.37.11 (US West)
+ - 162.255.36.11 (US East)
+ - 221.122.88.195 (China)
+ - 115.114.131.7 (India)
+ - 213.19.144.110 (EMEA)
+ - 103.122.166.55 (Australia)
+ - 209.9.211.110 (Hong Kong)
+ - 64.211.144.160 (Brazil)
+ - 69.174.57.160 (Canada)
+ - 207.226.132.110 (Japan)
+
+Meeting ID: **973 7236 9069**
+
+### Registration
+
+Please [**register**](https://forms.gle/XE5yzbVUAAjUoZTEA) by close of business Friday November 4th, 2022 if you plan to participate remotely so that you may receive email announcements and updates.  No registration fee is required.  You may still participate without registering.

--- a/_pages/meetings/spring2022.md
+++ b/_pages/meetings/spring2022.md
@@ -18,7 +18,7 @@ See [the full agenda](https://docs.google.com/spreadsheets/d/1J5bex4gwXKg2gAqW-X
 
 Materials associated with the meeting sessions will be kept in the [**meeting folder**](https://drive.google.com/drive/folders/1CCI5OSGNFcJwzpzgxaQMo8_s_oRN9j1o?usp=sharing) on Google Drive.
 
- - [Meeting schedule](https://docs.google.com/spreadsheets/d/1J5bex4gwXKg2gAqW-XWx9GftTPlDtH-4JKFOdURCb5s/edit?usp=sharing) (subject to change)
+ - [Meeting schedule](https://docs.google.com/spreadsheets/d/1J5bex4gwXKg2gAqW-XWx9GftTPlDtH-4JKFOdURCb5s/edit?usp=sharing)
  - [Hackathon projects](https://docs.google.com/spreadsheets/d/15ebuF2yN6zyfaFpCpoSWtoUdIjOZpx1KrzeiANEMRPk/edit?usp=sharing)
  - [Presentation and Tutorials Organizing](https://docs.google.com/spreadsheets/d/17RD7IS4Clw2GFGnqp3nCzYRdEVTG3vCMR8riZ4qgLCg/edit?usp=sharing)
 


### PR DESCRIPTION
Made the page, added a link to it in the Meetings page.

I also took the opportunity to fix up the 2022 Spring Meeting page (removed a "subject to change"). I happened to notice that we haven't uploaded a meeting report for spring 2022 yet, nor links to the meeting recordings. Do we want to fix that before merging this?

Remaining tasks after we merge this:
 - Add a link to the 2022 Fall Meeting page to the registration form
 - Make a blog post announcing the meeting?