### PR TITLE
Make Spring 2023 Meeting page

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -20,6 +20,11 @@ Meetings and telecon times are available as a [Google calendar](https://calendar
 
 ### Community Meetings
 
+[2023 Spring Python in Heliophysics Community Meeting]({% link
+_pages/meetings/spring2023.md %}), May 16–18 (hybrid in-person/remote).
+* [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1Gy2oquhdkkMfidRsf-WgjhnS7C5aIzuf?usp=sharing)
+* Meeting Report (to be produced shortly after the Spring 2023 meeting ends)
+
 [2022 Fall Python in Heliophysics Community Meeting]({% link
 _pages/meetings/fall2022.md %}), November 7–10 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/193ekRMe7TlcSnrlWrxkyHwu45VlOwurX?usp=sharing)

--- a/_pages/meetings/spring2023.md
+++ b/_pages/meetings/spring2023.md
@@ -5,7 +5,7 @@ permalink: /meetings/spring2023/
 exclude: true
 ---
 
-The spring 2023 meeting of the [Python in Heliophysics Community](http://heliopython.org) will be the first hybrid meeting to take place since the pre-pandemic times! We'll host the in-person portion at [**LASP \| CU-Boulder**](https://goo.gl/maps/mMapAsmgsg7DCrfZ7), and online participation will be available [**at this Zoom link**](https://cuboulder.zoom.us/j/97372369069) (Meeting ID: **973 7236 9069**). _The Zoom sessions will be recorded._ It will be spread across three days, starting Tuesday, May 16th, 2023 and ending Thursday, May 18th, 2023:
+The spring 2023 meeting of the [Python in Heliophysics Community](http://heliopython.org) will be the first hybrid meeting to take place since the pre-pandemic times! We'll host the in-person portion at [**LASP \| CU Boulder**](https://goo.gl/maps/mMapAsmgsg7DCrfZ7), and online participation will be available [**at this Zoom link**](https://cuboulder.zoom.us/j/97372369069) (Meeting ID: **973 7236 9069**). _The Zoom sessions will be recorded._ It will be spread across three days, starting Tuesday, May 16th, 2023 and ending Thursday, May 18th, 2023:
 
  - **Project updates and discussions:** May 16th 9:00 AM–5:00 PM (MDT)
  - **Unconference and tutorial sessions:** May 17th 9:00 AM–5:00 PM (MDT)

--- a/_pages/meetings/spring2023.md
+++ b/_pages/meetings/spring2023.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: 2023 Spring Python in Heliophysics Community Meeting
+permalink: /meetings/spring2023/
+exclude: true
+---
+
+The spring 2023 meeting of the [Python in Heliophysics Community](http://heliopython.org) will be the first hybrid meeting to take place since the pre-pandemic times! We'll host the in-person portion at [**LASP \| CU-Boulder**](https://goo.gl/maps/mMapAsmgsg7DCrfZ7), and online participation will be available [**at this Zoom link**](https://cuboulder.zoom.us/j/97372369069) (Meeting ID: **973 7236 9069**). _The Zoom sessions will be recorded._ It will be spread across three days, starting Tuesday, May 16th, 2023 and ending Thursday, May 18th, 2023:
+
+ - **Project updates and discussions:** May 16th 9:00 AM–5:00 PM (MDT)
+ - **Unconference and tutorial sessions:** May 17th 9:00 AM–5:00 PM (MDT)
+ - **Presentations and hackathons:** May 18th 9:00 AM–5:00 PM (MDT)
+
+See [the full agenda](https://docs.google.com/spreadsheets/d/1PdHCtgcVzr3kZg_jJxeZgvwjF1b7TbPO/edit?usp=sharing&ouid=111688094316717381127&rtpof=true&sd=true) for exact dates/times of the various sessions.
+<br><br><br>
+### Registration
+
+Please [**register**](https://forms.gle/nEpkZkn9BWzzDwrv7) by close of business Friday May 12th, 2023 if you plan to attend.  Registration is free and required for in-person attendees.  You may still participate remotely without registering.
+<br><br><br>
+
+### Session Documents and Presentations
+
+Materials associated with the meeting sessions will be kept in the [**meeting folder**](https://drive.google.com/drive/folders/1Gy2oquhdkkMfidRsf-WgjhnS7C5aIzuf?usp=sharing) on Google Drive.
+
+ - [Meeting schedule](https://docs.google.com/spreadsheets/d/1PdHCtgcVzr3kZg_jJxeZgvwjF1b7TbPO/edit?usp=sharing&ouid=111688094316717381127&rtpof=true&sd=true) _(work in progress)_
+ - [Meeting Organizing](https://docs.google.com/spreadsheets/d/1VXFATlx0AIqRTNiGQHHrE-BlZgM0d7Iu/edit?usp=share_link&ouid=105683901508483424618&rtpof=true&sd=true) _(work in progress)_
+
+#### Meeting Recordings
+
+ - _(Check back here after the meeting)_
+<br><br><br>
+
+### Meeting Location
+The meeting will be held in-person at the [**Laboratory for Atmospheric and Space Physics (LASP)**](https://goo.gl/maps/mMapAsmgsg7DCrfZ7) in the east campus of the University of Colorado, Boulder. 
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3055.977112804171!2d-105.2478674!3d40.008958799999995!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876bedc138bc2207%3A0x9f92aa579ccde89!2sLaboratory%20for%20Atmospheric%20and%20Space%20Physics!5e0!3m2!1sen!2sus!4v1678899163589!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+<br><br>
+
+### Zoom Meeting Information
+We will use Zoom for remote participation.
+<br><br>
+Join Zoom Meeting
+[**https://cuboulder.zoom.us/j/97372369069**](https://cuboulder.zoom.us/j/97372369069)
+
+Meeting ID: **973 7236 9069**
+
+One tap mobile
+ - +16699006833,,395871054# US (San Jose)
+ - +16465588656,,395871054# US (New York)
+
+Dial by your location
+ - +1 669 900 6833 US (San Jose)
+ - +1 646 558 8656 US (New York)
+
+Meeting ID: **973 7236 9069**
+
+Find your local number: https://cuboulder.zoom.us/u/ab3XRN96S2
+
+Join by SIP
+ - 395871054@zoomcrc.com
+
+Join by H.323
+ - 162.255.37.11 (US West)
+ - 162.255.36.11 (US East)
+ - 221.122.88.195 (China)
+ - 115.114.131.7 (India)
+ - 213.19.144.110 (EMEA)
+ - 103.122.166.55 (Australia)
+ - 209.9.211.110 (Hong Kong)
+ - 64.211.144.160 (Brazil)
+ - 69.174.57.160 (Canada)
+ - 207.226.132.110 (Japan)
+
+Meeting ID: **973 7236 9069**
+
+


### PR DESCRIPTION
Closes #265.

This PR creates the web page and adds it to the Meetings page. No blog post announcement yet.

The page is pretty similar to past pages, but I updated the layout slightly to accommodate in-person info and prioritize registration. Note the use of Google Maps links/embedding to give people directions. 

Also note the "_(work in progress)_" notes under Session Documents and Presentations.