### PR TITLE
Adds regularizePSF as a PyHC project

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -624,3 +624,16 @@
   software_maturity: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
+- name : "regularizePSF"
+  description: "A Python package for manipulating and correcting various point spread functions"
+  docs: "https://punch-mission.github.io/regularizepsf/"
+  code: "https://github.com/punch-mission/regularizepsf"
+  contact: "Marcus Hughes"
+  keywords: ["point-spread-function", "calibration", "general", "data", "FITS"]
+  community: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
+  documentation: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
+  testing: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
+  software_maturity: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
+  python3: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
+  license: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -630,7 +630,7 @@
   docs: "https://punch-mission.github.io/regularizepsf/"
   code: "https://github.com/punch-mission/regularizepsf"
   contact: "Marcus Hughes"
-  keywords: ["point-spread-function", "calibration", "general", "data", "FITS"]
+  keywords: ["plotting", "calibration", "general", "fits", "local", "data_analysis"]
   community: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
   documentation: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]
   testing: [ "https://img.shields.io/badge/Good-brightgreen.svg", "Good" ]


### PR DESCRIPTION
This PR adds [regularizePSF](https://github.com/punch-mission/regularizepsf) as a PyHC project. regularizePSF is a new tool made as part of the PUNCH mission (but applicable generally) to correct variable point-spread functions in images. 

I marked everything as green/good since I feel like we've adhered to the expected standards. Feel free to suggest otherwise if you see something missing. 

Also, I was a bit confused what keywords were acceptable. I did find the taxonomy mentioned in the SkyWinder PR, but it could be helpful to add that bit of instruction to the instructions for adding a project (or maybe it's there and I missed it). 

Finally, PUNCH might be added to the "Mission" taxonomy in the future. We will release more PUNCH specific packages. I didn't tag this one that way since it's not only applicable to PUNCH. 

Thanks! 