### PR TITLE
Add links to meeting recordings

### DIFF
--- a/_pages/meetings/spring2023.md
+++ b/_pages/meetings/spring2023.md
@@ -29,7 +29,9 @@ Materials associated with the meeting sessions will be kept in the [**meeting fo
 
 #### Meeting Recordings
 
- - _(Check back here after the meeting)_
+ - [Watch Day 1 here](https://youtu.be/6ZlH0yEyu08)
+ - [Watch Day 2 here](https://youtu.be/JwJR1cZ4EeI)
+ - [Watch Day 3 here](https://youtu.be/F9ra-517eog)
 <br><br><br>
 
 ### Meeting Location


### PR DESCRIPTION
Closes #284. Simply adding the links to the YouTube videos to the meeting page.