### PR TITLE
added in spring 2022 report, as well as updating past meeting report links to go to the persistent DOI identifier on Zenodo in place of google drive links

### DIFF
--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -33,38 +33,39 @@ _pages/meetings/fall2022.md %}), November 7–10 (remote).
 [2022 Spring Python in Heliophysics Community Meeting]({% link
 _pages/meetings/spring2022.md %}), May 16–19 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1CCI5OSGNFcJwzpzgxaQMo8_s_oRN9j1o?usp=sharing)
-* Meeting Report (to be produced shortly after the Spring 2022 meeting ends)
+* [Meeting Report](https://doi.org/10.5281/zenodo.8393964)
 
 [2021 Fall Python in Heliophysics Community Meeting]({% link
 _pages/meetings/fall2021.md %}), October 25–28 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/folders/1R81Q0gH09IV41sU9HUZGQWDwJ2YXa78Q?usp=sharing)
-* [Meeting Report](https://docs.google.com/document/d/1wS0LQSaq7GWGJJkmcUzBAZHdEUADQahwazSvkR37QGI/edit?usp=sharing)
+* [Meeting Report](https://doi.org/10.5281/zenodo.5745358)
 
 [2021 Spring Python in Heliophysics Community Meeting]({% link
 _pages/meetings/spring2021.md %}), May 10–13 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/1HcIQRnVmEXiTgNVx7cVL5mMySxVbUFYc)
-* [Meeting Report](https://docs.google.com/document/d/1G6Gr569NQ_j5FrW3fQkN-QtKazNznsDfHg39SOvnqSc/edit?usp=sharing)
+* [Meeting Report](https://doi.org/10.5281/zenodo.4784136)
 
 [2020 Fall Python in Heliophysics Community Meeting]({% link
 _pages/meetings/fall2020.md %}), October 26–November 16 (remote).
 * [Agenda, Presentations, Organization Spreadsheets, and Documents](https://drive.google.com/drive/u/0/folders/1T3CGRwXAst8jd7I6xFiKxyCgluGGpg0A)
-* [Meeting Report](https://docs.google.com/document/d/1roGSs_DKtXP5uLyPEHZrtA6taHW9zcMp0L54JKpg1p0/edit#heading=h.mpebd2k6hb5s)
+* [Meeting Report](https://doi.org/10.5281/zenodo.4728178)
 
 [2020 Spring Python in Heliophysics Community Meeting]({% link
 _pages/meetings/april2020.md %}), April 29 (remote).
 * [Presentations and Documents](https://drive.google.com/drive/u/0/folders/1vONfB6hf0y-VVOPj1748R3U9agFyq0iV)
-* [Meeting Report](https://docs.google.com/document/d/1FqR3u4nP4HtH6baIYyzehMeDDo6Qp5ivKtduPmHETFY/edit)
+* [Meeting Report](https://doi.org/10.5281/zenodo.4728184)
 
 2019 Fall Python in Heliophysics Community Meeting, November 4–6, 2019 (at LASP).
 * [Presentations and Documents](https://drive.google.com/drive/u/0/folders/1lSM0DwLuKli1Rv9eKYe0vBVB_V8_9wKB)
-* [Meeting Report](https://docs.google.com/document/d/187QNQuN_OWmM9jS9lZGjSQpUIIiCaCDtBHiw4DAqSmY/edit#heading=h.wk29adekc64s)
+* [Meeting Report](https://doi.org/10.5281/zenodo.4728161)
 
 2019 Spring Python in Heliophysics Community Meeting, May 21–23, 2019 (at LASP).
 * [Meeting materials](https://drive.google.com/drive/u/0/folders/171Ba3Mq3MIaEXoc9X91gZhaXHVjoJde2)
+* [Meeting Report](https://doi.org/10.5281/zenodo.4728159)
 
-2018 Python in Heliophysics Working Group Meeting, November 13–15, 2018 (at LASP).
-* [Meeting Report](https://docs.google.com/document/d/1ejP0kaibf6DRxjYJNmPrF1t3Nl21r0pC1FuDhu0hPnM/edit?usp=sharing)
+2018 Inaugural Python in Heliophysics Working Group Meeting, November 13–15, 2018 (at LASP).
 * [Presentations and Documents](https://drive.google.com/open?id=1snib9D8PcSaPByMqrAx8_4b05RfsTh58)
+* [Meeting Report](https://doi.org/10.5281/zenodo.2537188)
 * [Python in Heliophysics Community (PyHC) Standards](https://github.com/heliophysicsPy/standards/blob/main/standards.md)
 
 <br>

--- a/_pages/meetings/spring2022.md
+++ b/_pages/meetings/spring2022.md
@@ -24,9 +24,9 @@ Materials associated with the meeting sessions will be kept in the [**meeting fo
 
 #### Meeting Recordings
 
- - [Watch Day 1 here](https://o365coloradoedu-my.sharepoint.com/:v:/g/personal/juba8233_colorado_edu/ETAI1ZOECdJNjAoMZ97395MBUxeET_L0eEThl9wmuPUKYQ?e=5ggdtC)
- - [Watch Day 2 here](https://o365coloradoedu-my.sharepoint.com/:v:/g/personal/juba8233_colorado_edu/ERvp1e2ykJlDqGRojfIuWJMB9u0N0_WuCke6qig1d7RMFA?e=KArrGu)
- - [Watch Day 4 here](https://o365coloradoedu-my.sharepoint.com/:v:/g/personal/juba8233_colorado_edu/ESR7tt4NYrBKgTsOOXaDApoBdvd5-gwGOm-mDEZc_Xmgsw?e=koZdgm)
+ - [Watch Day 1 here](https://youtu.be/4oyylf7Odr0?si=2fdI7jLXqX4ftQJf)
+ - [Watch Day 2 here](https://youtu.be/-A85fD8B1JU?si=XHqNrZ1HOkh9MbJl)
+ - [Watch Day 4 here](https://youtu.be/qDF-8zAOHVw?si=eFzzozsbBZgPYSeD)
 
 ### Zoom Meeting Information
 


### PR DESCRIPTION
Again, self explanatory title. As usual, PR for posterity's sake, but merging it now.