### PR TITLE
Change old Matrix "riot.im" links to "element.io"

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -21,7 +21,7 @@ Follow [PyHC on Twitter](https://twitter.com/PyHC_official) for quick announceme
 <br>
 
 ## Chat rooms
-For more informal discussions and questions there is a chat room to enable live chat between users and developers. The chat is hosted on matrix and clicking the following [link](https://riot.im/app/#/room/#heliopython:openastronomy.org) will open a browser window with the chat interface. There is no need to install any software.
+For more informal discussions and questions there is a chat room to enable live chat between users and developers. The chat is hosted on matrix and clicking the following [link](https://app.element.io/#/room/#heliopython:openastronomy.org) will open a browser window with the chat interface. There is no need to install any software.
 
 We recently begun syncing this chat room with a Slack channel. Contact us for an invitation. 
 

--- a/_pages/docs/adding_to_pyhc_project_list.md
+++ b/_pages/docs/adding_to_pyhc_project_list.md
@@ -80,6 +80,6 @@ project, and what grades were assigned for the PyHC standards. If any of the sta
 make sure to provide some remarks about why that is, and what the project's plan is for improvement. As stated in the
 reviewing guidelines, at present, no projects will be rejected from the PyHC Project list. However, at the 
 PyHC Spring 2020 meeting we will set a date by which projects will be kicked off if they have any "Requires improvement" grades. 
-Feel free to also post about your project and the PR in the [Element chat group](https://riot.im/app/#/room/#heliopython:openastronomy.org). 
+Feel free to also post about your project and the PR in the [Element chat group](https://app.element.io/#/room/#heliopython:openastronomy.org). 
 Within a week or so, a PyHC developer will review your PR request and approve it (for now, unconditionally, but after the 
 PyHC Spring 2020 meeting approval is subject to the standards grades).

--- a/_pyhc_projects/adding_to_pyhc_project_list.md
+++ b/_pyhc_projects/adding_to_pyhc_project_list.md
@@ -72,6 +72,6 @@ project, and what grades were assigned for the PyHC standards. If any of the sta
 make sure to provide some remarks about why that is, and what the project's plan is for improvement. As stated in the
 reviewing guidelines, at present, no projects will be rejected from the PyHC Project list. However, at the 
 PyHC Spring 2020 meeting we will set a date by which projects will be kicked off if they have any "Requires improvement" grades. 
-Feel free to also post about your project and the PR in the [Element chat group](https://riot.im/app/#/room/#heliopython:openastronomy.org). 
+Feel free to also post about your project and the PR in the [Element chat group](https://app.element.io/#/room/#heliopython:openastronomy.org). 
 Within a week or so, a PyHC developer will review your PR request and approve it (for now, unconditionally, but after the 
 PyHC Spring 2020 meeting approval is subject to the standards grades).


### PR DESCRIPTION
This PR fixes the links to our Matrix chatroom from the old riot.im to the new element.io. I only did this in "normal" pages; I did not change meeting minutes or other records that had the old link.