### PR TITLE
'24 Summer School Updates

### DIFF
--- a/_pages/meetings/summer_school_24.md
+++ b/_pages/meetings/summer_school_24.md
@@ -11,12 +11,12 @@ The Python in Heliophysics Community (PyHC) is excited to announce its 2024 Summ
 
 This year's Summer School builds on the foundational success of its predecessor, offering an even deeper dive into the rich ecosystem of Heliophysics Python packages. Open to graduate students, early career scientists, and anyone eager to deepen their understanding of Python in the Heliophysics and Space Weather disciplines, this program promises a mix of in-depth tutorials, engaging demos, and hands-on sessions, delivered by some of the field's leading experts.
 
-Remote options will be available for those unable to make the trip to Boulder. Further, in keeping with PyHC’s commitment to knowledge-sharing, **this year's event remains FREE for all attendees**.
+Remote options will be available for those unable to make the trip to Boulder. The presentations will also be recorded and [streamed to YouTube](https://www.youtube.com/@pythoninheliophysicscommun3732). Further, in keeping with PyHC’s commitment to knowledge-sharing, **this year's event remains FREE for all attendees**.
 
 <br>
 
 ### Registration
-Check back here for registration info.
+Registration for the PyHC 2024 Summer School is now live. [Click here to sign up](https://forms.gle/cZRyJcjhv2QNVd3UA)! Once again, registration is FREE for all attendees. **The deadline for in-person and Zoom registration is Friday, April 19th, 2024.** After that date, we will not be able to accommodate additional requests for registration, however, you will still be able to access presentations via the live Zoom recording (not monitored for Q&A by Summer School organizers).
 
 <br>
 
@@ -28,26 +28,34 @@ Check back here for registration info.
 ### Location
 The Summer School will be held in-person at the [**Laboratory for Atmospheric and Space Physics (LASP)**](https://goo.gl/maps/mMapAsmgsg7DCrfZ7) in the east campus of the University of Colorado, Boulder. Parking passes will be provided and there is free wifi.
 
-Room LSTB-A200<br>
+Room SPSC-W120<br>
 Laboratory for Atmospheric and Space Physics (LASP)<br>
-1234 Innovation Dr.<br>
-Boulder, CO 80303<br>
+3665 Discovery Dr.<br>
+Boulder, CO 80309<br>
 USA<br>
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3055.977112804171!2d-105.2478674!3d40.008958799999995!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876bedc138bc2207%3A0x9f92aa579ccde89!2sLaboratory%20for%20Atmospheric%20and%20Space%20Physics!5e0!3m2!1sen!2sus!4v1678899163589!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3055.8459808428493!2d-105.24838192358133!3d40.01188778017926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876bedc3b5625603%3A0x725ff0c791cb1ebc!2sSpace%20Science%2C%203665%20Discovery%20Dr%2C%20Boulder%2C%20CO%2080309!5e0!3m2!1sen!2sus!4v1705013314375!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 <br>
 
 #### Zoom Meeting Information
 We will use Zoom for remote participation (details TBD).
 
 #### Hotel
-Check back here for hotel recommendations.
+The official recommended hotel for the PyHC 2024 summer school is the Hyatt Place Boulder/Pearl St, located at 2280 Junction Pl, Boulder, Colorado, United States, 80301 (approx. a five-minute drive to the SPSC building at LASP). We have reserved a block of rooms at the goverment per diem rate ($176/night with 12.5% room tax) for Sunday, May 19th to Saturday, May 25th, 2024. Parking at the hotel is $25/day. **The government rate is only guaranteed prior to the cut-off date of April 19th, 2024. After the cut-off date listed, guestrooms will be released back into the general inventory and will be sold at the prevailing rates.** To book your room for the summer school, [click here](https://www.hyatt.com/en-US/hotel/colorado/hyatt-place-boulder-pearl-street/denzb?corp_id=G-LAPC). 
 
-#### Bus
-Check back here for potential bus information.
+Please note: all individual reservations that wish to cancel must be canceled 7 days prior to reservation arrival date. Any reservations that are canceled after 7 days will be charged a cancellation fee equal to the amount of room and tax for their first night’s stay.
 
 <br>
+#### Transportation
+Plan to either rent a car to get from Denver International Aiport (DEN) to Boulder (approx. a 45-minute drive) and around Boulder itself, or, pay for a ride-share service/public transportation. Check out the below links for some options on public transportation. 
+* [Getting from DEN to Boulder](https://www.bouldercoloradousa.com/meetings-and-groups/start-planning/meeting-transportation/#driving)
+* [Getting around Boulder proper](https://www.bouldercoloradousa.com/meetings-and-groups/start-planning/meeting-transportation/#around)
 
+<br>
+### Official Language
+The official language of the PyHC 2022 Summer School is English. Simultaneous interpretation is not provided. It is therefore expected that attendees are able to communicate in the English language.
+
+<br>
 ### Python Resources
 You do not have to be a Python expert to attend. We will teach important Python best practices, but please use our <a href="{{ site.baseurl }}/docs/python_resources/">Python Resources</a> page to familiarize yourself with the basics if you have no prior experience with Python or Jupyter Notebooks, as those basics will not be taught.
 
@@ -59,9 +67,14 @@ Looking for notebooks or slides presented at the Summer School? They will be sto
 <br>
 
 ### Agenda
-Check back here for a detailed agenda.
+The agenda for the PyHC 2024 Summer School is a living document, and is subject to slight changes and tweaks as needed. The base material, however, is set. Note that we have incorporated longer lunch breaks to accommodate for the fact that _**lunches will not be provided.**_
 
+<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQKABPXS2MVQW5D36cA733KRXcCGSFIFqD612a--53r-Waji9NZcTzqBz4yDygkvheaL4bsxY6wz07z/pubhtml?gid=1085256662&amp;single=true&amp;widget=true&amp;headers=false" width="800" height="500" style="border:0;"></iframe>
 <br>
 
+### Summer School Code of Conduct
+We will follow the PyHC Code of Conduct for the PyHC 2024 Summer School ([see here](https://heliopython.org/docs/code_of_conduct/)). Those who violate the code of conduct are subject to removal from the remainder of summer school activities.
+
+<br>
 ### Additional Info
 Please email: <a href="mailto:pyhc-confidential@lasp.colorado.edu">pyhc-confidential@lasp.colorado.edu</a>

--- a/_pages/meetings/summer_school_24.md
+++ b/_pages/meetings/summer_school_24.md
@@ -16,7 +16,7 @@ Remote options will be available for those unable to make the trip to Boulder. T
 <br>
 
 ### Registration
-Registration for the PyHC 2024 Summer School is now live. [Click here to sign up](https://forms.gle/cZRyJcjhv2QNVd3UA)! Once again, registration is FREE for all attendees. **The deadline for in-person and Zoom registration is Friday, April 19th, 2024.** After that date, we will not be able to accommodate additional requests for registration, however, you will still be able to access presentations via the live Zoom recording (not monitored for Q&A by Summer School organizers).
+Registration for the PyHC 2024 Summer School is now live. [Click here to sign up](https://forms.gle/cZRyJcjhv2QNVd3UA)! Once again, registration is FREE for all attendees. **The deadline for both in-person and Zoom registration is Monday, April 29th, 2024.** After that date, we will not be able to accommodate additional requests for registration, however, you will still be able to access presentations via the live Zoom recording (not monitored for Q&A by Summer School organizers).
 
 <br>
 


### PR DESCRIPTION
Updated the Summer School web page to have the most up-to-date information. Asking for a quick once over to be sure nothing is glaringly wrong. We should push this soon, and get it more publicized on the overall PyHC website as well.