### PR TITLE
Add "Summer School" nav item

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,10 +12,13 @@
       <a class="navbar-brand" href="/">PyHC</a>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
+          <b><a class="nav-link {% if page.url == '/summer-school-24' %}active{% endif %}" href="/summer-school-24/">Summer School</a></b>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="https://heliopython.org/gallery/generated/gallery/index.html">Examples</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/blog/">Blog</a>
+          <a class="nav-link {% if page.url == '/blog' %}active{% endif %}" href="/blog/">Blog</a>
         </li>
         {% assign pages = site.pages | sort:'order' %}
         {% for p in pages %}

--- a/_pages/meetings.md
+++ b/_pages/meetings.md
@@ -83,6 +83,7 @@ _pages/meetings/april2020.md %}), April 29 (remote).
 * Be sure to submit by Wednesday, 2 August 2023 at 23:59 EDT. Abstracts will not be accepted for review after this date.
 
 
-#### Summer School
+#### Summer Schools
 
+* We are holding our <a href="{{ site.baseurl }}/summer-school-24">2024 Summer School</a> at the Laboratory for Atmospheric and Space Physics (LASP)! <a href="{{ site.baseurl }}/summer-school-24">Click here for more info</a>.
 * We recently held our inaugural <a href="{{ site.baseurl }}/summer-school">2022 Summer School</a>, in partnership with the European Space Astronomy Centre (ESAC)! <a href="{{ site.baseurl }}/summer-school">Click here for more info</a>.

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Blog
+permalink: /blog
 ---
 <p>subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
 


### PR DESCRIPTION
**This PR does three things:**

1. Adds a new nav item "**Summer School**" to the top site menu
     - Temporary: I'll remove it this year after the summer school
     - Bolded to draw attention
2. Adds an entry for this year's summer school to the Meetings page
3. Fixes a bug where "Blog" in the nav menu wasn't switching to black font when you're on the page

**Questions for Julie:**

1. We should make a blog post announcing the summer school next, right?
2. The Meetings page is starting to feel long and cluttered. Do you agree? I had an idea to move everything underneath the calendar into subpages: "**Community Meetings**", "**Conference Sessions**", "**Summer Schools**". Want me to?