### PR TITLE
Adds bits to check automatically PRs for trivial mistakes

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -1,0 +1,20 @@
+name: PR Tests
+
+on: [ pull_request ]
+
+jobs:
+  check_projects:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install pyyaml
+      - name: Run PR checker
+        run: |
+          python .github/workflows/pr_checker.py

--- a/.github/workflows/pr_checker.py
+++ b/.github/workflows/pr_checker.py
@@ -1,0 +1,58 @@
+import yaml
+from glob import glob
+import os
+import itertools
+import argparse
+
+here = os.path.dirname(__file__)
+root = os.path.abspath(f'{here}/../../')
+
+parser = argparse.ArgumentParser(
+    prog='pyhc website checker program',
+    description='Check that all yaml files are valid',
+    epilog='Enjoy the program! :)')
+
+parser.add_argument('-d', '--dry-run', action='store_true', help='Dry run')
+
+
+def ensure_all_yaml_files_are_valid(dry_run: bool = False):
+    for yaml_file in glob(f"{root}/**/*.yml", recursive=True):
+        try:
+            with open(yaml_file, "r") as f:
+                yaml.safe_load(f)
+        except Exception as e:
+            if dry_run:
+                print(f"Invalid yaml file: {yaml_file}")
+            else:
+                raise e
+
+
+def load_taxonomy():
+    with open(f"{root}/_data/taxonomy.yml", "r") as f:
+        t = yaml.safe_load(f)
+        return set(itertools.chain.from_iterable(map(lambda x: x["keywords"], t)))
+
+
+def check_keywords_respect_taxonomy(projects_file: str, dry_run: bool = False):
+    allowed_keywords: set = load_taxonomy()
+    with open(projects_file, "r") as f:
+        projects = yaml.safe_load(f)
+        for project in projects:
+            if "keywords" in project:
+                project_keywords = set(project["keywords"])
+                unlisted_keywords = project_keywords.difference(allowed_keywords)
+                if len(unlisted_keywords) > 0:
+                    if dry_run:
+                        print(f"Unlisted keywords for project {project['name']}: {unlisted_keywords}")
+                    else:
+                        raise Exception(f"Unlisted keywords for project {project['name']}: {unlisted_keywords}")
+            else:
+                print(f"Project {project['name']} has no keywords")
+
+
+if __name__ == "__main__":
+    dry_run = parser.parse_args().dry_run
+    ensure_all_yaml_files_are_valid(dry_run=dry_run)
+    check_keywords_respect_taxonomy(f"{root}/_data/projects_core.yml", dry_run=dry_run)
+    check_keywords_respect_taxonomy(f"{root}/_data/projects.yml", dry_run=dry_run)
+    check_keywords_respect_taxonomy(f"{root}/_data/projects_unevaluated.yml", dry_run=dry_run)

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -176,7 +176,7 @@
   description: "Retreive data from many space physics Web services"
   docs: https://speasy.readthedocs.io/
   contact: Alexis Jeandet
-  keywords: ["heliosphere", "magnetosphere", "data_retrieval", "web_service", "remote"]
+  keywords: ["heliosphere", "plasma_physics", "magnetosphere", "data_retrieval", "data_container", "general", "cdf", "csv", "ascii", "cdaweb", "local", "remote", "sscweb", "web_service", "data_access"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -3,6 +3,7 @@
   docs: https://afino-release-version.readthedocs.io/
   description: A tool for finding oscillations in time series data
   contact: Andrew Inglis
+  keywords: ["data_analysis"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
@@ -57,7 +58,7 @@
   docs: "https://geospacelab.readthedocs.io/en/latest/"
   code: "https://github.com/JouleCai/geospacelab"
   contact: "Lei Cai"
-  keywords: ["geospace","ionosphere_thermosphere_mesosphere","magnetosphere","data_retrieval","data_containe","plotting","data_access", "data_analysis"]
+  keywords: ["geospace","ionosphere_thermosphere_mesosphere","magnetosphere","data_retrieval","data_container","plotting","data_access", "data_analysis"]
   community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Partially met"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
@@ -149,7 +150,7 @@
   description: "Data loader for Solar Orbiter/EPD energetic charged particle sensors EPT, HET, and STEP"
   docs: https://github.com/jgieseler/solo-epd-loader#readme=
   contact: Jan Gieseler
-  keywords: ["data", "data_access", "data_retrieval", "heliosphere", "heliophysics", "instrumentation", "solar", "space physics", "specific"]
+  keywords: ["data_access", "data_retrieval", "heliosphere","instrumentation", "solar", "specific"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Requires%20improvement-red.svg", "Requires improvement"]
@@ -162,7 +163,7 @@
   description: "A CCSDS telemetry packet decoding library based on the XTCE packet format description standard."
   docs: "https://space-packet-parser.readthedocs.io"
   contact: "Gavin Medley"
-  keywords: ["ccsds", "xtce", "space data systems", "space packet protocol", "packet parsing", "lasp", "university of colorado", "data processing", "data extraction", "data manipulation", "data transformation", "data encoding", "data decoding", "packet inspection", "binary data", "python"]
+  keywords: ["ccsds", "xtce", "packet_parsing", "packet_inspection", "data_analysis", "data_assimilation", "binary"]
   community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
@@ -175,7 +176,7 @@
   description: "Retreive data from many space physics Web services"
   docs: https://speasy.readthedocs.io/
   contact: Alexis Jeandet
-  keywords: ["heliophysics", "space physics", "magnetospheric physics", "data_retrieval", "web_service", "remote", "data"]
+  keywords: ["heliosphere", "magnetosphere", "data_retrieval", "web_service", "remote"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
@@ -255,7 +256,7 @@
   docs: "https://docs.sunpy.org/projects/ndcube"
   code: "https://github.com/sunpy/ndcube"
   contact: "Dan Ryan"
-  keywords: ["heliophysics", "solar", "astrophysics", "n-dimensional", "data", "container objects", "visualization", "data manipulation"]
+  keywords: ["coordinates", "data_analysis", "data_container", "heliosphere", "plotting", "solar"]
   community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
@@ -297,7 +298,7 @@
   docs: "https://aidapy.readthedocs.io"
   description: "A Python package to provide machine learning and statistical methods to heliophysics data"
   contact: "Romain Dupuis, Jorge Amaya, Giovanni Lapenta"
-  keyword: ["machine learning", "heliophysics", "statistics", "data"]
+  keywords: ["machine_learning", "heliosphere", "data_analysis"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
@@ -310,7 +311,7 @@
   docs: "https://github.com/tsssss/geopack/blob/master/README.md"
   code: "https://github.com/tsssss/geopack"
   contact: "Sheng Tian"
-  keywords: ["heliophysics", "space physics", "magnetospheric physics"]
+  keywords: ["heliosphere", "magnetosphere"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
@@ -349,7 +350,7 @@
   docs: "https://docs.sunpy.org/projects/sunraster"
   code: "https://github.com/sunpy/sunraster"
   contact: "Nabil Freij"
-  keywords: ["solar", "data_container", "spectral", "plotting", "general", "fits"]
+  keywords: ["solar", "data_container", "spectra", "plotting", "general", "fits"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
@@ -401,7 +402,7 @@
   docs: "https://irispy-lmsal.readthedocs.io"
   code: "https://gitlab.com/LMSAL_HUB/iris_hub/irispy-lmsal"
   contact: "Nabil Freij"
-  keywords: ["solar", "specific", "data_analysis", "spectral", "fits", "time", "coordinates","plotting", "multidimensional"]
+  keywords: ["solar", "specific", "data_analysis", "spectra", "fits", "time", "coordinates","plotting", "multidimensional"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
@@ -543,7 +544,7 @@
   description: LOFAR solar and spaceweather data processing
   logo: https://lofar-sun-tools.readthedocs.io/en/latest/_static/logo0.png
   contact: Peijin Zhang
-  keywords: ["Solar_radio", "LOFAR"]
+  keywords: ["lofar"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Requires%20improvement-red.svg", "Requires improvement"]

--- a/_data/projects_core.yml
+++ b/_data/projects_core.yml
@@ -61,7 +61,7 @@
   docs: "https://pyspedas.readthedocs.io"
   code: "https://github.com/spedas/pyspedas"
   contact: "Jim Lewis"
-  keywords: ["ace","arase","cdf","cluster","coordinates","csswe","data","data_access","dscovr","equator_s","fast","geotail","heliophysics","image","kyoto_dst","line_plots","magnetospheric physics","maven","mica","mms","plotting","poes","polar","psp","solo","space physics","spectra","stereo","themis","twins","ulysses","van_allen_probes","wind"]
+  keywords: ["ace","arase","cdf","cluster","coordinates","csswe","data_access","dscovr","equator_s","fast","geotail","heliosphere","image","kyoto_dst","line_plots","magnetosphere","maven","mica","mms","plotting","poes","polar","psp","solo","spectra","stereo","themis","twins","ulysses","van_allen_probes","wind"]
   community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]

--- a/_data/taxonomy.yml
+++ b/_data/taxonomy.yml
@@ -4,7 +4,7 @@
 
 - category: "Functionality"
   description: "The functionality available in a package"
-  keywords: ["2D_graphics", "3D_graphics", "calibration", "ccsds", "coordinates", "data_container", "data_retrieval", "image_processing", "interactive", "line_plots", "machine_learning", "multidimensional", "orbit", "plotting", "power_spectra", "spectra", "time"]
+  keywords: ["2D_graphics", "3D_graphics", "calibration", "ccsds", "coordinates", "data_container", "data_retrieval", "image_processing", "interactive", "line_plots", "machine_learning", "multidimensional", "orbit", "packet_parsing", "packet_inspection", "plotting", "power_spectra", "spectra", "time", "xtce"]
 
 - category: "Span"
   description: "The user scope of a project"
@@ -12,7 +12,7 @@
 
 - category: "Input/Output Formats"
   description: "The different data formats a package reads and/or writes"
-  keywords: ["ascii", "cdf", "csv", "fits", "hdf5", "idl_save", "netcdf"]
+  keywords: ["ascii", "binary", "cdf", "csv", "fits", "hdf5", "idl_save", "netcdf"]
 
 - category: "Input Sources"
   description: "The ability of a project to access web service data/local data"
@@ -24,4 +24,4 @@
 
 - category: "Mission"
   description: "Observational, including ground and satellite, and also models. TODO."
-  keywords: ["ace", "adelphi", "amgeo", "arase", "bats_r_us", "cluster", "csswe", "ctipe", "de2", "dmsp", "dscovr", "enlil", "equator_s", "fast", "fermi", "gamera", "geotail", "gitm", "goes", "hermes", "hinode", "icon", "igrf", "image", "iri", "kyoto_dst", "lasco", "madrigal", "maven", "mica", "mms", "omni", "openggcm", "poes", "polar", "proba_2", "psp", "rhessi", "sami2", "sami3", "sdo", "shue", "soho", "solo", "stereo", "superdarn", "swmf", "themis", "tiegcm", "tsyganenko", "twins", "ulysses", "van_allen_probes", "waccmx", "wind"]
+  keywords: ["ace", "adelphi", "amgeo", "arase", "bats_r_us", "cluster", "csswe", "ctipe", "de2", "dmsp", "dscovr", "enlil", "equator_s", "fast", "fermi", "gamera", "geotail", "gitm", "goes", "hermes", "hinode", "icon", "igrf", "image", "iri", "kyoto_dst", "lasco", "lofar", "madrigal", "maven", "mica", "mms", "omni", "openggcm", "poes", "polar", "proba_2", "psp", "rhessi", "sami2", "sami3", "sdo", "shue", "soho", "solo", "stereo", "superdarn", "swmf", "themis", "tiegcm", "tsyganenko", "twins", "ulysses", "van_allen_probes", "waccmx", "wind"]


### PR DESCRIPTION
I would like to propose the idea to check PRs with CI so we get a feedback quickly and this also ensures trivial mistakes won't be missed by humans.
So far, only checks for yaml validity and correct usage of keywords in projects but I would be happy to add more and improve the script.

I've run the script locally and here is the output:
```
python3 .github/workflows/pr_checker.py -d
Unlisted keywords for project pySPEDAS: {'data', 'space physics', 'heliophysics', 'magnetospheric physics'}
Project AFINO has no keywords
Unlisted keywords for project GeospaceLAB: {'data_containe'}
Unlisted keywords for project solo-epd-loader: {'data', 'space physics', 'heliophysics'}
Unlisted keywords for project space-packet-parser: {'python', 'data encoding', 'data manipulation', 'space packet protocol', 'data transformation', 'data decoding', 'packet parsing', 'xtce', 'binary data', 'university of colorado', 'lasp', 'packet inspection', 'data extraction', 'data processing', 'space data systems'}
Unlisted keywords for project Speasy: {'data', 'space physics', 'heliophysics', 'magnetospheric physics'}
Unlisted keywords for project NDCube: {'data manipulation', 'visualization', 'container objects', 'astrophysics', 'heliophysics', 'data', 'n-dimensional'}
Project aidapy has no keywords
Unlisted keywords for project geopack: {'space physics', 'heliophysics', 'magnetospheric physics'}
Unlisted keywords for project sunraster: {'spectral'}
Unlisted keywords for project irispy-lmsal: {'spectral'}
Unlisted keywords for project lofarSun: {'LOFAR', 'Solar_radio'}

```