### PR TITLE
Adds more projects description checks and refac to check everything per project

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: |
-          python -m pip install pyyaml
+          python -m pip install pyyaml termcolor
       - name: Run PR checker
         run: |
           python .github/workflows/pr_checker.py

--- a/.github/workflows/pr_checker.py
+++ b/.github/workflows/pr_checker.py
@@ -42,6 +42,8 @@ def check_project_keywords_respect_taxonomy(project: Dict, dry_run: bool = False
     if "keywords" in project:
         project_keywords = set(project["keywords"])
         unlisted_keywords = project_keywords.difference(allowed_keywords)
+        if len(project_keywords) == 0:
+            print(colored(f"Warning project {project['name']} has no keywords"), "yellow")
         if len(unlisted_keywords) > 0:
             print(f"Unlisted keywords for project {project['name']}: {unlisted_keywords}")
             return False
@@ -83,14 +85,6 @@ def check_project_has_grades(project: Dict, dry_run: bool = False) -> bool:
     return True
 
 
-def check_project_has_functionality_related_keyword(project: Dict) -> bool:
-    functionality_related_keywords = functionally_related_keywords()
-    if len(set(project["keywords"]).intersection(functionality_related_keywords)) == 0:
-        print(f"Project {project['name']} has no functionality related keyword")
-        return False
-    return True
-
-
 def main():
     dry_run = parser.parse_args().dry_run
     ensure_all_yaml_files_are_valid(dry_run=dry_run)
@@ -103,7 +97,6 @@ def main():
                 print(f"Checking project {project['name']} in file {projects_file}")
                 passes = all((
                     check_project_has_mandatory_fields(project),
-                    check_project_has_functionality_related_keyword(project),
                     check_project_keywords_respect_taxonomy(project),
                     check_project_has_grades(project)
                 ))

--- a/.github/workflows/pr_checker.py
+++ b/.github/workflows/pr_checker.py
@@ -95,7 +95,7 @@ def main():
     dry_run = parser.parse_args().dry_run
     ensure_all_yaml_files_are_valid(dry_run=dry_run)
     any_failed = False
-    for projects_file in glob(f"{root}/_data/projects*.yml", recursive=True):
+    for projects_file in (f"{root}/_data/projects.yml", f"{root}/_data/projects_core.yml"):
         with open(projects_file, "r") as f:
             projects = yaml.safe_load(f)
             for project in projects:

--- a/.github/workflows/pr_checker.py
+++ b/.github/workflows/pr_checker.py
@@ -43,7 +43,8 @@ def check_project_keywords_respect_taxonomy(project: Dict, dry_run: bool = False
         project_keywords = set(project["keywords"])
         unlisted_keywords = project_keywords.difference(allowed_keywords)
         if len(project_keywords) == 0:
-            print(colored(f"Warning project {project['name']} has no keywords"), "yellow")
+            print(f"Project {project['name']} has no keywords")
+            return False
         if len(unlisted_keywords) > 0:
             print(f"Unlisted keywords for project {project['name']}: {unlisted_keywords}")
             return False

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -60,7 +60,7 @@
   contact: "Lei Cai"
   keywords: ["geospace","ionosphere_thermosphere_mesosphere","magnetosphere","data_retrieval","data_container","plotting","data_access", "data_analysis"]
   community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Partially met"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]


### PR DESCRIPTION
@sapols a little more work for you or related projects maintainers 😅:

```
python3 .github/workflows/pr_checker.py -d
--------------------------------------------------------------------------------
Checking project ACEmag in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project ACEmag misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project ACEmag has no functionality related keyword
Project ACEmag failed checks
--------------------------------------------------------------------------------
Checking project AstrometryAzEl in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project AstrometryAzEl misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project AstrometryAzEl has no functionality related keyword
Project AstrometryAzEl failed checks
--------------------------------------------------------------------------------
Checking project Auroral Electrojet in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project Auroral Electrojet misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project Auroral Electrojet has no functionality related keyword
Project Auroral Electrojet failed checks
--------------------------------------------------------------------------------
Checking project DASCutils in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project DASCutils misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project DASCutils has no functionality related keyword
Project DASCutils failed checks
--------------------------------------------------------------------------------
Checking project Digital Meridian Spectrometer in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project Digital Meridian Spectrometer misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project Digital Meridian Spectrometer has no functionality related keyword
Project Digital Meridian Spectrometer failed checks
--------------------------------------------------------------------------------
Checking project GEOrinex in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project GEOrinex misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project GEOrinex has no functionality related keyword
Project GEOrinex failed checks
--------------------------------------------------------------------------------
Checking project GOESutils in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project GOESutils misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project GOESutils has no functionality related keyword
Project GOESutils failed checks
--------------------------------------------------------------------------------
Checking project GIMAmag in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project GIMAmag misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project GIMAmag has no functionality related keyword
Project GIMAmag failed checks
--------------------------------------------------------------------------------
Checking project GLOW in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project GLOW misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project GLOW has no functionality related keyword
Project GLOW failed checks
--------------------------------------------------------------------------------
Checking project HWM-93 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project HWM-93 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project HWM-93 has no functionality related keyword
Project HWM-93 failed checks
--------------------------------------------------------------------------------
Checking project IGRF-13 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project IGRF-13 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project IGRF-13 has no functionality related keyword
Project IGRF-13 failed checks
--------------------------------------------------------------------------------
Checking project IRI-2016 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project IRI-2016 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project IRI-2016 has no functionality related keyword
Project IRI-2016 failed checks
--------------------------------------------------------------------------------
Checking project IRI-90 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project IRI-90 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project IRI-90 has no functionality related keyword
Project IRI-90 failed checks
--------------------------------------------------------------------------------
Checking project LOWTRAN in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project LOWTRAN misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project LOWTRAN has no functionality related keyword
Project LOWTRAN failed checks
--------------------------------------------------------------------------------
Checking project Maidenhead in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project Maidenhead misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project Maidenhead has no functionality related keyword
Project Maidenhead failed checks
--------------------------------------------------------------------------------
Checking project MGSutils in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project MGSutils misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project MGSutils has no functionality related keyword
Project MGSutils failed checks
--------------------------------------------------------------------------------
Checking project POLAN in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project POLAN misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project POLAN has no functionality related keyword
Project POLAN failed checks
--------------------------------------------------------------------------------
Checking project PyGemini in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project PyGemini misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project PyGemini has no functionality related keyword
Project PyGemini failed checks
--------------------------------------------------------------------------------
Checking project PyMap3D in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project PyMap3D misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project PyMap3D has no functionality related keyword
Project PyMap3D failed checks
--------------------------------------------------------------------------------
Checking project PyZenodo in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project PyZenodo misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project PyZenodo has no functionality related keyword
Project PyZenodo failed checks
--------------------------------------------------------------------------------
Checking project ReesAurora in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project ReesAurora misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project ReesAurora has no functionality related keyword
Project ReesAurora failed checks
--------------------------------------------------------------------------------
Checking project Scanning Doppler Interferometer in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project Scanning Doppler Interferometer misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project Scanning Doppler Interferometer has no functionality related keyword
Project Scanning Doppler Interferometer failed checks
--------------------------------------------------------------------------------
Checking project ScienceDates in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project ScienceDates misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project ScienceDates has no functionality related keyword
Project ScienceDates failed checks
--------------------------------------------------------------------------------
Checking project THEMISasi in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project THEMISasi misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project THEMISasi has no functionality related keyword
Project THEMISasi failed checks
--------------------------------------------------------------------------------
Checking project WMM2020 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project WMM2020 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project WMM2020 has no functionality related keyword
Project WMM2020 failed checks
--------------------------------------------------------------------------------
Checking project WMM2015 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project WMM2015 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project WMM2015 has no functionality related keyword
Project WMM2015 failed checks
--------------------------------------------------------------------------------
Checking project MSISE-00 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project MSISE-00 misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project MSISE-00 has no functionality related keyword
Project MSISE-00 failed checks
--------------------------------------------------------------------------------
Checking project MadrigalWeb in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project MadrigalWeb misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project MadrigalWeb has no functionality related keyword
Project MadrigalWeb failed checks
--------------------------------------------------------------------------------
Checking project NEXRADutils in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_unevaluated.yml
Project NEXRADutils misses mandatory fields: {'software_maturity', 'testing', 'license', 'documentation', 'community', 'python3'}
Project NEXRADutils has no functionality related keyword
Project NEXRADutils failed checks
--------------------------------------------------------------------------------
Checking project AFINO in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project AFINO has no functionality related keyword
Project AFINO failed checks
--------------------------------------------------------------------------------
Checking project CCSDSPy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project CCSDSPy passed checks
--------------------------------------------------------------------------------
Checking project dbprocessing in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project dbprocessing has no functionality related keyword
Project dbprocessing failed checks
--------------------------------------------------------------------------------
Checking project enlilviz in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project enlilviz passed checks
--------------------------------------------------------------------------------
Checking project GeospaceLAB in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project GeospaceLAB deos not respect grades for field documentation, got ['https://img.shields.io/badge/Good-brightgreen.svg', 'Partially met']
Project GeospaceLAB failed checks
--------------------------------------------------------------------------------
Checking project OMMBV in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project OMMBV has no functionality related keyword
Project OMMBV failed checks
--------------------------------------------------------------------------------
Checking project pyDARN in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project pyDARN has no functionality related keyword
Project pyDARN failed checks
--------------------------------------------------------------------------------
Checking project sami2py in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project sami2py has no functionality related keyword
Project sami2py failed checks
--------------------------------------------------------------------------------
Checking project SkyWinder in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project SkyWinder has no functionality related keyword
Project SkyWinder failed checks
--------------------------------------------------------------------------------
Checking project SkyWinder-Analysis in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project SkyWinder-Analysis passed checks
--------------------------------------------------------------------------------
Checking project solarmach in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project solarmach passed checks
--------------------------------------------------------------------------------
Checking project solo-epd-loader in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project solo-epd-loader passed checks
--------------------------------------------------------------------------------
Checking project space-packet-parser in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project space-packet-parser passed checks
--------------------------------------------------------------------------------
Checking project Speasy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project Speasy passed checks
--------------------------------------------------------------------------------
Checking project fiasco in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project fiasco has no functionality related keyword
Project fiasco failed checks
--------------------------------------------------------------------------------
Checking project OCBpy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project OCBpy has no functionality related keyword
Project OCBpy failed checks
--------------------------------------------------------------------------------
Checking project AACGMV2 in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project AACGMV2 has no functionality related keyword
Project AACGMV2 failed checks
--------------------------------------------------------------------------------
Checking project apexpy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project apexpy has no functionality related keyword
Project apexpy failed checks
--------------------------------------------------------------------------------
Checking project SpiceyPy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project SpiceyPy has no functionality related keyword
Project SpiceyPy failed checks
--------------------------------------------------------------------------------
Checking project NDCube in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project NDCube passed checks
--------------------------------------------------------------------------------
Checking project viresclient in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project viresclient passed checks
--------------------------------------------------------------------------------
Checking project aiapy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project aiapy has no functionality related keyword
Project aiapy failed checks
--------------------------------------------------------------------------------
Checking project aidapy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project aidapy passed checks
--------------------------------------------------------------------------------
Checking project geopack in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project geopack has no functionality related keyword
Project geopack failed checks
--------------------------------------------------------------------------------
Checking project MCALF in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project MCALF passed checks
--------------------------------------------------------------------------------
Checking project hissw in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project hissw has no functionality related keyword
Project hissw failed checks
--------------------------------------------------------------------------------
Checking project sunraster in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project sunraster passed checks
--------------------------------------------------------------------------------
Checking project sunkit-image in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project sunkit-image has no functionality related keyword
Project sunkit-image failed checks
--------------------------------------------------------------------------------
Checking project sunkit-instruments in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project sunkit-instruments has no functionality related keyword
Project sunkit-instruments failed checks
--------------------------------------------------------------------------------
Checking project pyflct in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project pyflct has no functionality related keyword
Project pyflct failed checks
--------------------------------------------------------------------------------
Checking project irispy-lmsal in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project irispy-lmsal passed checks
--------------------------------------------------------------------------------
Checking project XRTpy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project XRTpy has no functionality related keyword
Project XRTpy failed checks
--------------------------------------------------------------------------------
Checking project regularizePSF in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project regularizePSF passed checks
--------------------------------------------------------------------------------
Checking project TomograPy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project TomograPy has no functionality related keyword
Project TomograPy failed checks
--------------------------------------------------------------------------------
Checking project python-magnetosphere in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project python-magnetosphere has no functionality related keyword
Project python-magnetosphere failed checks
--------------------------------------------------------------------------------
Checking project pysatCDF in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project pysatCDF has no functionality related keyword
Project pysatCDF failed checks
--------------------------------------------------------------------------------
Checking project pyglow in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project pyglow has no functionality related keyword
Project pyglow failed checks
--------------------------------------------------------------------------------
Checking project geodata in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project geodata has no functionality related keyword
Project geodata failed checks
--------------------------------------------------------------------------------
Checking project fisspy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project fisspy has no functionality related keyword
Project fisspy failed checks
--------------------------------------------------------------------------------
Checking project CDFlib in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project CDFlib has no functionality related keyword
Project CDFlib failed checks
--------------------------------------------------------------------------------
Checking project PyTplot in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project PyTplot has no functionality related keyword
Project PyTplot failed checks
--------------------------------------------------------------------------------
Checking project lofarSun in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project lofarSun has no functionality related keyword
Project lofarSun failed checks
--------------------------------------------------------------------------------
Checking project PyGS in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project PyGS passed checks
--------------------------------------------------------------------------------
Checking project HERMES-Core in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project HERMES-Core passed checks
--------------------------------------------------------------------------------
Checking project PyCDFpp in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project PyCDFpp has no functionality related keyword
Project PyCDFpp failed checks
--------------------------------------------------------------------------------
Checking project SciQLop in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects.yml
Project SciQLop passed checks
--------------------------------------------------------------------------------
Checking project SunPy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project SunPy passed checks
--------------------------------------------------------------------------------
Checking project pysat in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project pysat passed checks
--------------------------------------------------------------------------------
Checking project PlasmaPy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project PlasmaPy passed checks
--------------------------------------------------------------------------------
Checking project SpacePy in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project SpacePy passed checks
--------------------------------------------------------------------------------
Checking project pySPEDAS in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project pySPEDAS passed checks
--------------------------------------------------------------------------------
Checking project Kamodo in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project Kamodo passed checks
--------------------------------------------------------------------------------
Checking project HAPI Client in file /home/jeandet/Documents/prog/GH-stuff/heliophysicsPy.github.io/_data/projects_core.yml
Project HAPI Client passed checks
```