### PR TITLE
summer_school_24: fix the year in "official language" note

### DIFF
--- a/_pages/meetings/summer_schools/summer_school_24.md
+++ b/_pages/meetings/summer_schools/summer_school_24.md
@@ -53,7 +53,7 @@ Plan to either rent a car to get from Denver International Aiport (DEN) to Bould
 
 <br>
 ### Official Language
-The official language of the PyHC 2022 Summer School is English. Simultaneous interpretation is not provided. It is therefore expected that attendees are able to communicate in the English language.
+The official language of the PyHC 2024 Summer School is English. Simultaneous interpretation is not provided. It is therefore expected that attendees are able to communicate in the English language.
 
 <br>
 ### Python Resources


### PR DESCRIPTION
World's smallest PR. The Official Language section for the 2024 summer school said "The official language of the PyHC 2022 Summer School is English" (copypasta for the win). Changes that to 2024.