### PR TITLE
Poster abstract submissions addition to summer school info

### DIFF
--- a/_pages/meetings/summer_schools/summer_school_24.md
+++ b/_pages/meetings/summer_schools/summer_school_24.md
@@ -33,6 +33,12 @@ Funding specifications: Once applications have been reviewed, we will award flat
 [Apply for the NSF-sponsored travel funding here](https://forms.gle/iZTQhkWoiA3XB6fW8). **Applications are due by Monday, April 29th, 2024.**
 
 <br>
+### Poster Abstract Submissions
+If you are attending the PyHC 2024 summer school on site in Boulder, CO at LASP, and are interested in presenting on your work within Heliophysics/Space Physics and Python, the summer school poster session is your best bet! Bonus points if you can show work you've done that leverages the PyHC ecosystem. Please fill out the Google form linked below so that we can adequately plan for the poster session, and ensure all submissions are on topic.
+
+[Submit PyHC 2024 summer school poster abstracts here](https://forms.gle/rYV8KFP9moazTxwC8). **Abstract submissions are due by Monday, May 6th, 2024 at 11:59 PM MT.**
+
+<br>
 #### Hotel
 The official recommended hotel for the PyHC 2024 summer school is the Hyatt Place Boulder/Pearl St, located at 2280 Junction Pl, Boulder, Colorado, United States, 80301 (approx. a five-minute drive to the SPSC building at LASP). We have reserved a block of rooms at the goverment per diem rate ($176/night with 12.5% room tax) for Sunday, May 19th to Saturday, May 25th, 2024. Parking at the hotel is $25/day. **The government rate is only guaranteed prior to the cut-off date of April 19th, 2024. After the cut-off date listed, guestrooms will be released back into the general inventory and will be sold at the prevailing rates.** To book your room for the summer school, [click here](https://www.hyatt.com/en-US/hotel/colorado/hyatt-place-boulder-pearl-street/denzb?corp_id=G-LAPC).
 

--- a/_posts/2024-03-21-summer-school-poster-abstract-submission.markdown
+++ b/_posts/2024-03-21-summer-school-poster-abstract-submission.markdown
@@ -1,0 +1,13 @@
+---
+layout: post
+title: "Poster Abstract Submission Open for the PyHC 2024 Summer School"
+author: jibarnum
+---
+
+<img src="/../img/page_images/summer-school-24.jpg" alt="Summer School Monday, 20 May 2024 – Friday, 24 May 2024" style="display: block; margin-left: auto; margin-right: auto; width: 60%">
+
+As a reminder, the Python in Heliophysics Community (PyHC) 2024 Summer School is set to take place Monday, May 20th to Friday, May 24th at the prestigious Laboratory for Atmospheric and Space Physics (LASP) in scenic Boulder, Colorado, USA and online on Zoom. This year’s Summer School builds on the foundational success of its predecessor, offering an even deeper dive into the rich ecosystem of Heliophysics Python packages. Open to undergraduate and graduate students, early career scientists, and anyone eager to deepen their understanding of Python in the Heliophysics and Space Weather disciplines, this program promises a mix of in-depth tutorials, engaging demos, and hands-on sessions, delivered by some of the field’s leading experts. If you have not yet registered for the summer school, it is free to do so and a link for it can be located on [the summer school's web page](https://pyhc.org/summer-school-24). You'll also find there a link to suggesting housing, NSF travel support applications, specific location, the agenda, and other important information. 
+
+If you plan to attend the PyHC 2024 summer school **on site** in Boulder, CO at LASP, and are interested in presenting on your work within Heliophysics/Space Physics and Python, the summer school poster session is your best bet! Bonus points if you can show work you've done that leverages the PyHC ecosystem. We have created a Google form to which you can submit your abstracts for the poster session, which will help the organizing committee adequately plan for the poster session, and ensure all submissions are on topic. 
+
+[Submit PyHC 2024 summer school poster abstracts here](https://forms.gle/rYV8KFP9moazTxwC8). **Deadline for abstract submission is Monday, May 6th, 2024 at 11:59 PM MT.** 


### PR DESCRIPTION
Announcing summer school poster abstract submission through a new blog post, and adding info to the summer school web page. Double checking for any glaring mistakes. If you think I missed anything important on the Google form itself, too, let me know and I'll update that.