### PR TITLE
Remove Summer School nav item

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,6 @@
       <a class="navbar-brand" href="/">PyHC</a>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <b><a class="nav-link {% if page.url == '/summer-school-24' %}active{% endif %}" href="/summer-school-24">Summer School</a></b>
-        </li>
-        <li class="nav-item">
           <a class="nav-link" href="https://heliopython.org/gallery/generated/gallery/index.html">Examples</a>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
We temporarily added a "**Summer School**" nav item to the website to better advertise the 2024 Summer School. Now that the event has passed, it's time to remove that nav item.