### PR TITLE
Removes python3 status from projects table

### DIFF
--- a/_includes/project_cards.html
+++ b/_includes/project_cards.html
@@ -46,7 +46,6 @@
               <th scope="col">Documentation</th>
               <th scope="col">Testing</th>
               <th scope="col">Software Maturity</th>
-              <th scope="col">Python 3</th>
               <th scope="col">License</th>
             </tr>
           </thead>
@@ -81,7 +80,6 @@
               <td>{% if project.documentation != blank %}<p class="hidden">{{ project.documentation[1] }}</p><img src="{{ project.documentation[0] }}" alt="{{ project.documentation[project.documentation.length-1] }}">{% endif %}</td>
               <td>{% if project.testing != blank %}<p class="hidden">{{ project.testing[1] }}</p><img src="{{ project.testing[0] }}" alt="{{ project.testing[project.testing.length-1] }}">{% endif %}</td>
               <td>{% if project.software_maturity != blank %}<p class="hidden">{{ project.software_maturity[1] }}</p><img src="{{ project.software_maturity[0] }}" alt="{{ project.software_maturity[project.software_maturity.length-1] }}">{% endif %}</td>
-              <td>{% if project.python3 != blank %}<p class="hidden">{{ project.python3[1] }}</p><img src="{{ project.python3[0] }}" alt="{{ project.python3[project.python3.length-1] }}">{% endif %}</td>
               <td>{% if project.license != blank %}<p class="hidden">{{ project.license[1] }}</p><img src="{{ project.license[0] }}" alt="{{ project.license[project.license.length-1] }}">{% endif %}</td>
             </tr>
             {% endfor %}

--- a/_pyhc_projects/adding_to_pyhc_project_list.md
+++ b/_pyhc_projects/adding_to_pyhc_project_list.md
@@ -27,7 +27,6 @@ inputs are starred, and variable names are shown in parentheses):
 * The grade for the documentation standard &ast;
 * The grade for the testing standard &ast;
 * The grade for the software maturity standard &ast;
-* The grade for the Python 3 standard &ast;
 * The grade for the license standard &ast;
 
 The standards grades each require two values to be entered in, the img src url and the alt text of the given grade. The img
@@ -60,7 +59,6 @@ yml file. An example project's inputs are shown below.
   documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]   
   testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]   
   software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]  
-  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]   
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]  
   
 If your project logo is in GitHub, use a link to the raw image or else it won't render in the "card" view on the PyHC Projects page.


### PR DESCRIPTION
Resolves #330 

There was a suggestion to not show the "Python 3 standard" requirement in the projects table. This PR removes showing that column and doesn't suggest for it to be included in new reviews.

I did not remove the data from the [project yaml](https://github.com/heliophysicsPy/heliophysicsPy.github.io/blob/main/_data/projects.yml) though. There are two projects in the table that are not Python 3 compliant. I think they should be moved off the project list but I'll leave that to someone else's discretion. (Both packages haven't really been touched for 14 years. I was the last commit on TomograPy to suggest going to a different package.)
