### PR TITLE
Include PHEP 2

### DIFF
--- a/_data/pheps.yml
+++ b/_data/pheps.yml
@@ -13,3 +13,18 @@
   Status: Final
   Title: PHEP Purpose and Guidelines
   Type: Process
+- Author: Jonathan T. Niehof <jtniehof@gmail.com> <https://orcid.org/0000-0001-6286-5809>
+  Content-Type: text/markdown; charset="UTF-8"; variant="CommonMark"
+  Created: 06-Dec-2023
+  DOI: 10.5281/zenodo.14187913
+  Discussions-To: https://github.com/heliophysicsPy/standards/pull/25
+  Filename: phep-0002.md
+  PHEP: 2
+  Post-History: 06-Dec-2023, 28-Feb-2024, 20-Aug-2024, 19-Nov-2024
+  Requires: 1
+  Resolution: https://docs.google.com/document/d/12IGirV5RM50LqhifXBE_UzY10LDuoVxaS5bG6QWlL4M/edit,
+    https://docs.google.com/document/d/1znmDP59xo19L7ohv0HhH9vVWirG2nK95lIXy2y1UHEM/edit
+  Revision: 1
+  Status: Final
+  Title: PHEP Template
+  Type: Informational


### PR DESCRIPTION
Adds PHEP 2 to the pheps.yml file.

Should be merged after heliophysicsPy/standards#25 (which I'm putting a little more information in now).