### PR TITLE
Adding SAMMI to projects.yml

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -480,6 +480,21 @@
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
+- name: "SAMMI"
+  code: "https://github.com/swxsoc/sammi"
+  description: "Manage attributes for ISTP CDF files using YAML"
+  docs: "https://swxschema.readthedocs.io/en/latest/"
+  logo: "https://raw.githubusercontent.com/swxsoc/sammi/e764c4c84d5e511799ffc47d446a76f17501b8a2/docs/logo/sammi_logo.png"
+  contact: "Maxine Hartnett"
+  keywords: ["general", "cdf", "data_access"]
+  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
+
 - name: "SAVIC"
   description: "Stability Analysis Vitalizing Instability Classification - a Python package for predicting, quantifying and classifying ion-driven plasma instabilities"
   docs: "https://savic.readthedocs.io/en/latest/index.html"


### PR DESCRIPTION
Adding [SAMMI](https://github.com/swxsoc/sammi) to the projects page. 

SAMMI is a CDF attribute manager tool to create ISTP-compliant CDF file attributes. It's a collaboration between SWxSOC and the IMAP SDC. It's a small but flexible tool which allows teams to store variable attributes in VCS friendly YAML files and create attributes that align with standard formats. The attributes are returned as Python dictionaries for inputs into data structures such as xarray datasets or astropy datatables. 

SAMMI is released on PyPi and used in both IMAP and SWxSOC processing. 

Grades:
community: good
documentation: good
testing: good
software maturity: good
license: good

The license is under Apache 2.0 - I see PyHC recommends BSD 2 or 3. It's my understanding that Apache 2 and BSD 3 are reasonably compatible, and it's a permissive license, so I marked that as good. But, I would appreciate confirmation that Apache 2 actually meets that standard. 