### PR TITLE
Add ORCIDs to People page

### DIFF
--- a/_data/leaders.yml
+++ b/_data/leaders.yml
@@ -2,8 +2,10 @@
   name: "Julie Barnum"
   role: "Principal Investigator"
   affiliation: "LASP"
+  orcid: "0000-0001-8755-0694"
 
 - handle: "sapols"
   name: "Shawn Polson"
   role: "Technical Lead"
   affiliation: "LASP"
+  orcid: "0000-0003-0619-5745"

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -5,28 +5,35 @@
 - handle: "ehsteve"
   name: "Steven D. Christe"
   affiliation: "NASA GSFC"
+  orcid: "0000-0001-6127-795X"
 
 - handle: "cadair"
   name: "Stuart Mumford"
+  orcid: "0000-0003-4217-4642"
 
 - handle: "kdere"
   name: "Ken Dere"
+  orcid: "0000-0003-1628-6261"
 
 - handle: "aburrell"
   name: "Angeline G. Burrell"
   affiliation: "NRL"
+  orcid: "0000-0001-8875-9326"
 
 - handle: "jklenzing"
   name: "Jeffrey Klenzing"
   affiliation: "NASA GSFC"
+  orcid: "0000-0001-8321-6074"
 
 - handle: "rstoneback"
   name: "Russell Stoneback"
   affiliation: "UT Dallas"
+  orcid: "0000-0001-7216-4336"
 
 - handle: "ayshih"
   name: "Albert Shih"
   affiliation: "NASA GSFC"
+  orcid: "0000-0001-6874-2594"
 
 - handle: "wafels"
   name: "Jack Ireland"
@@ -35,6 +42,7 @@
 - handle: "wtbarnes"
   name: "Will Barnes"
   affiliation: "Rice University"
+  orcid: "0000-0001-9642-6089"
 
 - handle: "timduly4"
   name: "Timothy Duly"
@@ -44,24 +52,29 @@
 
 - handle: "rjarvinen"
   name: "Riku Jarvinen"
+  orcid: "0000-0002-4246-2954"
 
 - handle: "jswoboda"
   name: "John Swoboda"
+  orcid: "0000-0003-2627-2031"
 
 - handle: "dpq"
   name: "David Parunakian"
   affiliation: ""
+  orcid: "0000-0002-5468-4060"
 
-- handle: scivision
-  name: Michael Hirsch
+- handle: "scivision"
+  name: "Michael Hirsch"
 
 - handle: "AndrewAnnex"
   name: "Andrew Annex"
   affiliation: "Johns Hopkins University"
+  orcid: "0000-0002-0253-2313"
 
 - handle: "namurphy"
   name: "Nick Murphy"
   affiliation: "Harvard-Smithsonian Center for Astrophysics"
+  orcid: "0000-0001-6628-8033"
 
 - handle: "DanRyanIrish"
   name: "Dan Ryan"
@@ -70,22 +83,27 @@
 - handle: "drsteve"
   name: "Steve Morley"
   affiliation: "Los Alamos National Laboratory"
+  orcid: "0000-0001-8520-0199"
 
 - handle: "blalterman"
   name: "B. L. Alterman"
   affiliation: "University of Michigan"
+  orcid: "0000-0001-6673-3432"
 
 - handle: "mbobra"
   name: "Monica Bobra"
   affiliation: "Stanford University"
+  orcid: "0000-0002-5662-9604"
   
 - handle: "alex-aquila"
   name: "Alexandria Ware"
   affiliation: "LASP"
+  orcid: "0000-0003-4647-9718"
 
 - handle: "jtniehof"
   name: "Jon Niehof"
   affiliation: "UNH"
+  orcid: "0000-0001-6286-5809"
 
 - handle: "smithara"
   name: "Ashley Smith"
@@ -94,22 +112,27 @@
 - handle: "aharonroberts"
   name: "D. Aaron Roberts"
   affiliation: ""
+  orcid: "0000-0001-6565-2921"
   
 - handle: "darrendezeeuw"
   name: "Darren De Zeeuw"
   affiliation: ""
+  orcid: "0000-0002-4313-5998"
   
 - handle: "BaptisteCecconi"
   name: "Baptiste Cecconi"
   affiliation: ""
+  orcid: "0000-0001-7915-5571"
   
 - handle: "hayesla"
   name: "Laura Hayes"
   affiliation: ""
+  orcid: "0000-0002-6835-2390"
   
 - handle: "cdkharris"
   name: "Camilla D.K. Harris"
   affiliation: ""
+  orcid: "0000-0001-5045-8827"
   
 - handle: "neerajkulk"
   name: "Neeraj Kulkarni"
@@ -118,10 +141,12 @@
 - handle: "rweigel"
   name: "Bob Weigel"
   affiliation: ""
+  orcid: "0000-0002-9521-5228"
   
 - handle: "bryan-harter"
   name: "Bryan Harter"
   affiliation: "LASP"
+  orcid: "0000-0002-3148-121X"
   
 - handle: "abbyazari"
   name: "Abby Azari"
@@ -134,10 +159,12 @@
 - handle: "starfleetjames"
   name: "James Mason"
   affiliation: ""
+  orcid: "0000-0002-3783-5509"
   
 - handle: "balapoduval"
   name: "Bala Poduval"
   affiliation: ""
+  orcid: "0000-0003-1258-0308"
 
 - handle: "tsssss"
   name: "Sheng Tian"
@@ -146,20 +173,23 @@
 - handle: "sandyfreelance"
   name: "Sandy Antunes"
   affiliation: ""
+  orcid: "0000-0002-3098-2602"
 
 - handle: "Dolgalad"
   name: "Alexandre Schulz"
   affiliation: "IRAP"
   
 - handle: "rebeccaringuette"
-  name: Rebecca Ringuette
+  name: "Rebecca Ringuette"
   affiliation: "NASA CCMC"
   orcid: "0000-0003-0875-2023"
 
 - handle: "jmbhughes"
-  name: Marcus Hughes
+  name: "Marcus Hughes"
   affiliation: "SwRI"
+  orcid: "0000-0003-3410-7650"
 
 - handle: "jameswilburlewis"
-  name: Jim Lewis
+  name: "Jim Lewis"
   affiliation: "UC Berkeley Space Sciences Lab"
+  orcid: "0009-0005-4191-5906"

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -131,7 +131,7 @@
   name: "Josh Elliott"
   affiliation: "LASP"
   
-- handle: "jmason86"
+- handle: "starfleetjames"
   name: "James Mason"
   affiliation: ""
   
@@ -154,6 +154,7 @@
 - handle: "rebeccaringuette"
   name: Rebecca Ringuette
   affiliation: "NASA CCMC"
+  orcid: "0000-0003-0875-2023"
 
 - handle: "jmbhughes"
   name: Marcus Hughes

--- a/_pages/people.html
+++ b/_pages/people.html
@@ -4,7 +4,7 @@ title: People
 permalink: /people/
 order: 4
 ---
-{% assign sorted_team = site.data.members | sort:'handle' %}
+{% assign sorted_team = site.data.members | sort:'name' %}
 {% assign leaders = site.data.leaders %}
 <div class="container-fluid">
 

--- a/_pages/people.html
+++ b/_pages/people.html
@@ -13,10 +13,13 @@ order: 4
         {% for leader in leaders %}
         <div class="col-lg-2 col-md-3 col-sm-4 col-xs-12">
             <div class="card" style="margin:0px;padding:0px;background-color:#ffffff;border:0;box-shadow:none">
-                <img class="card-img-top img-fluid rounded-circle" src="https://github.com/{{ leader.handle }}.png"/>
+                <img class="card-img-top img-fluid rounded-circle" src="https://github.com/{{ leader.handle }}.png" alt="{{ leader.name }}"/>
                 <div class="card-body">
                     <h6 class="card-title">{{ leader.role }}</h6>
                     <h6 class="card-title">@{{ leader.handle }}</h6>
+                    {% if leader.orcid %}
+                    <h6 class="card-title"><a href="https://orcid.org/{{ leader.orcid }}">{{ leader.orcid }}</a></h6>
+                    {% endif %}
                     <h6 class="card-title">{{ leader.name }}</h6>
                 </div>
             </div>
@@ -29,9 +32,12 @@ order: 4
         {% for member in sorted_team %}
         <div class="col-lg-2 col-md-3 col-sm-4 col-xs-12">
             <div class="card" style="margin:0px;padding:0px;background-color:#ffffff;border:0;box-shadow:none">
-                <img class="card-img-top img-fluid rounded-circle" src="https://github.com/{{ member.handle }}.png"/>
+                <img class="card-img-top img-fluid rounded-circle" src="https://github.com/{{ member.handle }}.png" alt="{{ member.name }}"/>
                 <div class="card-body">
                     <h6 class="card-title">@{{ member.handle }}</h6>
+                    {% if member.orcid %}
+                    <h6 class="card-title"><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></h6>
+                    {% endif %}
                     <h6 class="card-title">{{ member.name }}</h6>
                 </div>
             </div>


### PR DESCRIPTION
This PR adds ORCIDs to the people page. If a member or leader has an "orcid" entry in their respective yaml file, it'll display on the page and link to their ORCID profile.

I've added the easily findable ORCIDs. Others will have to add their own (or tell me what it is so I can add it).