### PR TITLE
Update space-packet-parser repo location after moving to LASP Github org

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -573,7 +573,7 @@
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
 - name: "space-packet-parser"
-  code: "https://github.com/medley56/space_packet_parser"
+  code: "https://github.com/lasp/space_packet_parser"
   description: "A CCSDS telemetry packet decoding library based on the XTCE packet format description standard."
   docs: "https://space-packet-parser.readthedocs.io"
   contact: "Gavin Medley"


### PR DESCRIPTION
Space Packet Parser was recently moved to the LASP Github org. This PR updates the metadata pointing to the repo (and adds a couple of keywords).