### PR TITLE
Added asilib to projects.yml 

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -77,6 +77,20 @@
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
+- name: "asilib"
+  description: "asilib is an open source package providing data access and analysis tools for the world’s all-sky imager (ASI) data."
+  docs: "https://aurora-asi-lib.readthedocs.io/"
+  code: "https://github.com/mshumko/asilib"
+  logo: "http://raw.githubusercontent.com/mshumko/asilib/refs/heads/main/docs/_static/asilib_logo.png"
+  contact: "Mykhaylo (Mike) Shumko"
+  keywords: ["ionosphere_thermosphere_mesosphere", "data_retrieval", "image_processing", "plotting", "general", "remote", "data_access", "data_analysis", "instrumentation", "themis", "igrf"]
+  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
 - name: CCSDSPy
   code: https://github.com/ccsdspy/ccsdspy/
   description: A Python package for reading CCSDS (spacecraft) packet data.


### PR DESCRIPTION
The [asilib](https://aurora-asi-lib.readthedocs.io/) package provides a unified Python 3 framework for accessing, analyzing, and visualizing all-sky imager (ASI) data from various networks like REGO, THEMIS, TREx, and MANGO. It enables tasks such as keogram and movie generation, auroral mapping, and conjunction analysis with other data sources, streamlining research by offering a consistent interface for diverse ASI datasets.

asilib is archived on [PyPI](http://pypi.org/project/asilib/) and [Zenodo](https://zenodo.org/records/15013736).

Grades:
community: good
documentation: good
testing: partially met*
software maturity: good
license: good

*Since our tests require downloading ASI data, they are slower than desired and occasionally crash due to unstable connection. We will mitigate this by mocking most of the I/O bound tests. Currently the code coverage is at ~75%, and tests are run automatically via GitHub Actions.