### PR TITLE
Document Tech Lead use of PyHC Standards Evaluator; drop stale 2020 dates

### DIFF
--- a/_pages/docs/adding_to_pyhc_project_list.md
+++ b/_pages/docs/adding_to_pyhc_project_list.md
@@ -80,8 +80,11 @@ on your forked repository's GitHub page. This will create a request to merge tho
 website repository. In this PR, write a short blurb about your project, including the name, a general description of the 
 project, and what grades were assigned for the PyHC standards. If any of the standards fall below the "Good" classification,
 make sure to provide some remarks about why that is, and what the project's plan is for improvement. As stated in the
-reviewing guidelines, at present, no projects will be rejected from the PyHC Project list. However, at the 
-PyHC Spring 2020 meeting we will set a date by which projects will be kicked off if they have any "Requires improvement" grades. 
+reviewing guidelines, at present, no projects will be rejected from the PyHC Project list. However, we will 
+eventually set a date by which projects will be kicked off if they have any "Requires improvement" grades. 
 Feel free to also post about your project and the PR in the [Element chat group](https://app.element.io/#/room/#heliopython:openastronomy.org). 
-Within a week or so, a PyHC developer will review your PR request and approve it (for now, unconditionally, but after the 
-PyHC Spring 2020 meeting approval is subject to the standards grades).
+Within a week or so, the PyHC Tech Lead will review your PR. As part of this review, the Tech Lead generates a 
+standards report using the [PyHC Standards Evaluator](https://github.com/heliophysicsPy/pyhc-standards-evaluator)—an 
+AI tool that evaluates a package against PyHC's standards—and compares it against your self-evaluation. If the report 
+agrees with your grades, the PR can be merged at the Tech Lead's discretion. If it disagrees, the Tech Lead will 
+discuss the differences with you in the PR until a final set of grades is agreed upon (the Tech Lead has final say).

--- a/_pyhc_projects/adding_to_pyhc_project_list.md
+++ b/_pyhc_projects/adding_to_pyhc_project_list.md
@@ -70,8 +70,11 @@ on your forked repository's GitHub page. This will create a request to merge tho
 website repository. In this PR, write a short blurb about your project, including the name, a general description of the 
 project, and what grades were assigned for the PyHC standards. If any of the standards fall below the "Good" classification,
 make sure to provide some remarks about why that is, and what the project's plan is for improvement. As stated in the
-reviewing guidelines, at present, no projects will be rejected from the PyHC Project list. However, at the 
-PyHC Spring 2020 meeting we will set a date by which projects will be kicked off if they have any "Requires improvement" grades. 
+reviewing guidelines, at present, no projects will be rejected from the PyHC Project list. However, we will 
+eventually set a date by which projects will be kicked off if they have any "Requires improvement" grades. 
 Feel free to also post about your project and the PR in the [Element chat group](https://app.element.io/#/room/#heliopython:openastronomy.org). 
-Within a week or so, a PyHC developer will review your PR request and approve it (for now, unconditionally, but after the 
-PyHC Spring 2020 meeting approval is subject to the standards grades).
+Within a week or so, the PyHC Tech Lead will review your PR. As part of this review, the Tech Lead generates a 
+standards report using the [PyHC Standards Evaluator](https://github.com/heliophysicsPy/pyhc-standards-evaluator)—an 
+AI tool that evaluates a package against PyHC's standards—and compares it against your self-evaluation. If the report 
+agrees with your grades, the PR can be merged at the Tech Lead's discretion. If it disagrees, the Tech Lead will 
+discuss the differences with you in the PR until a final set of grades is agreed upon (the Tech Lead has final say).

--- a/_pyhc_projects/pyhc_project_grading_guidelines.md
+++ b/_pyhc_projects/pyhc_project_grading_guidelines.md
@@ -10,8 +10,8 @@ with respect to how well their project stacks up to each of the review standards
 If a project's grade for a standard falls below the "Good" classification, the reviewer should provide some remarks about
 why that is, and what the project's plan is for improvement.
 
-At present, no projects will be rejected from the PyHC Project list. However, at the PyHC Spring 2020 meeting we will
-set a date by which projects will be kicked off if they have any "Requires improvement" grades.
+At present, no projects will be rejected from the PyHC Project list. However, we will eventually set a date by which
+projects will be kicked off if they have any "Requires improvement" grades.
 We will also set up a timeline for which projects are 1) informed they are in danger of being kicked off and 2) given
 time to fix the problematic categories.
 
@@ -20,7 +20,7 @@ A more detailed description of a review's grading colors is shown below.
 <table>
 <tr>
 <td><img src="https://img.shields.io/badge/Requires%20improvement-red.svg" alt="Requires improvement"></td>
-<td>At present, we won't reject any projects that have a standard with this grade, however, projects are strongly encouraged to improve. Note that this is going to change in the latter part of 2020.</td>
+<td>At present, we won't reject any projects that have a standard with this grade, however, projects are strongly encouraged to improve. Note that this is going to change in the future.</td>
 </tr>
 <tr>
 <td><img src="https://img.shields.io/badge/Partially%20met-orange.svg" alt="Partially met"></td>


### PR DESCRIPTION
## Summary

Two related updates to the PyHC project submission docs:

1. **Document the PyHC Tech Lead's use of the [PyHC Standards Evaluator](https://github.com/heliophysicsPy/pyhc-standards-evaluator).** When a submitter opens a PR with their self-evaluation grading badges, the Tech Lead now generates a standards report using the evaluator AI tool and compares it against the self-evaluation. If they agree, the PR can be merged at the Tech Lead's discretion; if they disagree, the Tech Lead discusses with the submitter in the PR until a final set of grades is agreed upon (Tech Lead has final say). The review process itself is unchanged — the Tech Lead has always done this — there's just an AI tool to help now. Also corrects "a PyHC developer will...approve it unconditionally" to "the PyHC Tech Lead will...approve at the Tech Lead's discretion."
2. **Drop stale "Spring 2020 meeting" / "by 2020" framing** in both the submission instructions and the grading guidelines. Replaced with future-tense wording so the *intent* (we will eventually start enforcing red-grade rejections) is preserved without the dead deadline.

Files changed:
- `_pages/docs/adding_to_pyhc_project_list.md` (Jekyll/website version) — both updates
- `_pyhc_projects/adding_to_pyhc_project_list.md` (GitHub markdown version) — both updates, kept in sync with the Jekyll copy
- `_pyhc_projects/pyhc_project_grading_guidelines.md` — 2020-date cleanup only

A matching PR in [`pyhc-standards-evaluator`](https://github.com/heliophysicsPy/pyhc-standards-evaluator) will apply the same 2020-date cleanup to that repo's byte-identical copy of `pyhc_project_grading_guidelines.md`.

## Test plan

- [x] Render the `_pages/docs/adding_to_pyhc_project_list.md` page locally (or in the PR preview if available) and confirm the updated paragraph renders correctly, with the evaluator link working.
- [x] Spot-check that no "2020" references remain in any of the three modified files.
- [x] Confirm the two `adding_to_pyhc_project_list.md` copies remain aligned in content (only formatting differences).
