### PR TITLE
Adding in new AGU 2026 info to conference sessions page

### DIFF
--- a/_pages/meetings/conference_sessions/conference_sessions.md
+++ b/_pages/meetings/conference_sessions/conference_sessions.md
@@ -5,12 +5,15 @@ permalink: /meetings/conference_sessions
 exclude: true
 ---
 
-### AGU Fall 2024 Meeting
+### AGU Fall 2026 Meeting
 
 #### AGU Sessions
-* PyHC poster session: [_SM43C - Innovative Python Software in Solar and Space Physics_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Session/225308)
-    * Date/Time: Thursday, 12 December 2024 (1:40 PM - 5:30 PM ET)
+* PyHC poster session: [_SA020 - Python Software Coordination in Solar and Space Physics_](https://agu.confex.com/agu/agu26/prelim.cgi/Session/281988)
+    * Description: This session seeks to highlight the PyHC effort, with an emphasis on creating new collaborations, highlighting innovative improvements to existing PyHC software, and increasing awareness of current PyHC resources. We invite contributions from Python software packages across the solar and space physics community: heliophysics, magnetospheres, ITM physics, atmospheres, space weather, and planetary sciences, including both scientific software and infrastructure projects. Submissions that further PyHC's goals are particularly desired, including: 1) new (or new to PyHC) Python packages ideal for integration with PyHC, 2) updates to existing PyHC projects, 3) increased interoperability with Python software packages (especially within existing PyHC software), or 4) integration with cloud-based software.
+    * Submit your abstract [here](https://agu.confex.com/agu/agu26/sa/papers/index.cgi?sessionid=281988)!
+    * **Astracts due no later than Wednesday, 5 August 2026, 23:59 PM EDT (03:59 UTC)**
 
+<!-- 
 * Other sessions of interest
     * [_IN13C - Open to Celebrate!: Open Science Success Stories in Helio and Geosciences Poster_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Session/229151)
         * Date/Time: Monday, 9 December 2024 (1:40 PM - 5:30 PM ET)
@@ -20,7 +23,7 @@ exclude: true
         * Date/Time: Thursday, 12 December 2024 (12:30 PM - 1:30 PM ET)
 
 * PyHC-specific posters and talks (not in the PyHC poster session)
-    * [_The Python in Heliophysics Community: a “north star” for open-source software communities (Julie Barnum)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1524747)
+/    * [_The Python in Heliophysics Community: a “north star” for open-source software communities (Julie Barnum)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1524747)
     * [_Leaning into Open Science with the Python in Heliophysics Community Summer School Series (Julie Barnum)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1532801)
     * [_PyHC-Chat: A Chatbot for the Python in Heliophysics Community (Shawn Polson)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1529613)
-
+-->

--- a/_pages/meetings/conference_sessions/conference_sessions.md
+++ b/_pages/meetings/conference_sessions/conference_sessions.md
@@ -23,7 +23,7 @@ exclude: true
         * Date/Time: Thursday, 12 December 2024 (12:30 PM - 1:30 PM ET)
 
 * PyHC-specific posters and talks (not in the PyHC poster session)
-/    * [_The Python in Heliophysics Community: a “north star” for open-source software communities (Julie Barnum)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1524747)
+    * [_The Python in Heliophysics Community: a “north star” for open-source software communities (Julie Barnum)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1524747)
     * [_Leaning into Open Science with the Python in Heliophysics Community Summer School Series (Julie Barnum)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1532801)
     * [_PyHC-Chat: A Chatbot for the Python in Heliophysics Community (Shawn Polson)_](https://agu.confex.com/agu/agu24/meetingapp.cgi/Paper/1529613)
 -->


### PR DESCRIPTION
We still had info from AGU 2024 up ☠️. Updated with current information.