### PR TITLE
Prevent scheduled website workflows from running in forks

### DIFF
--- a/.github/workflows/phep3_email_reminder.yml
+++ b/.github/workflows/phep3_email_reminder.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   send-reminder:
+    # Production email must never be sent from contributor forks.
+    if: github.repository == 'heliophysicsPy/heliophysicsPy.github.io'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update_phep3_schedule.yml
+++ b/.github/workflows/update_phep3_schedule.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   update-schedule:
+    # Generated schedule commits must only be created in the canonical repository.
+    if: github.repository == 'heliophysicsPy/heliophysicsPy.github.io'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Motivation

The PyHC website documents fork-and-pull as its contribution model, so contributors are expected to carry copies of these workflow files in their forks.

Someone reported receiving scheduled-workflow notifications from his website fork after GitHub Actions had been enabled there. Investigation showed two unintended fork-side effects:

- The quarterly email reminder attempted to send the production PHEP 3 email without the upstream repository secrets and [failed authentication](https://github.com/rweigel/heliophysicsPy.github.io/actions/runs/28530287023).
- The weekly schedule updater has repeatedly committed generated schedule changes directly to the fork's default branch, most recently in [this run](https://github.com/rweigel/heliophysicsPy.github.io/actions/runs/28781319898).

Forks should remain valid contribution workspaces without running the canonical repository's operational automation.

## What changed

- Guard the `PHEP 3 Quarterly Email Reminder` job with an exact canonical-repository check.
- Apply the same guard to the `Update PHEP 3 Schedule Weekly` job.
- Leave the pull-request test workflow unchanged.

Both guarded jobs now run only when:

```yaml
github.repository == 'heliophysicsPy/heliophysicsPy.github.io'
```

If Actions or either workflow is enabled in a contributor fork, GitHub may still create the scheduled workflow run, but these jobs will skip before checking out code, accessing secrets, sending email, or committing generated files.

## Validation

- Both workflow files parse as valid YAML.
- `actionlint 1.7.12` passes with unrelated existing `setup-python@v4` and shell-quoting diagnostics suppressed.
- `git diff --check` passes.
