### PR TITLE
add madrigalweb to project list

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -322,6 +322,20 @@
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
+  - name: madrigalWeb
+  url: "https://github.com/MITHaystack/madrigalWeb"
+  code: "https://github.com/MITHaystack/madrigalWeb"
+  docs: "https://madrigalweb.readthedocs.io/en/latest"
+  description: MadrigalWeb - a python API to access the Madrigal database
+  contact: K Cariglia
+  keywords: ["geospace", "data_retrieval", "ascii", "hdf5", "netcdf", "web_service", "data_access"]
+  community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  documentation: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  software_maturity: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
 - name: "MCALF"
   description: "Accurately constraining velocity information from spectral imaging observations using machine learning techniques."
   docs: "https://mcalf.macbride.me"

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -322,12 +322,12 @@
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
-  - name: madrigalWeb
-  url: "https://github.com/MITHaystack/madrigalWeb"
+- name: "MadrigalWeb"
+  url: "https://cedar.openmadrigal.org"
   code: "https://github.com/MITHaystack/madrigalWeb"
-  docs: "https://madrigalweb.readthedocs.io/en/latest"
-  description: MadrigalWeb - a python API to access the Madrigal database
-  contact: K Cariglia
+  docs: "https://madrigalweb.readthedocs.io/en/latest/"
+  description: "MadrigalWeb - a Python API to access the Madrigal database"
+  contact: "Katherine Cariglia"
   keywords: ["geospace", "data_retrieval", "ascii", "hdf5", "netcdf", "web_service", "data_access"]
   community: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   documentation: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
@@ -781,4 +781,3 @@
   software_maturity: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
-

--- a/_data/projects_unevaluated.yml
+++ b/_data/projects_unevaluated.yml
@@ -170,13 +170,6 @@
   contact: Michael Hirsch
   keywords: ["ionosphere_thermosphere_mesosphere","specific"]
 
-- name: "MadrigalWeb"
-  url: "http://cedar.openmadrigal.org"
-  description: "Access data from any Madrigal database."
-  code: "https://pypi.org/project/madrigalWeb"
-  contact: "Bill Rideout"
-  keywords: ["ionosphere_thermosphere_mesosphere","general"]
-
 - name: NEXRADutils
   code: https://github.com/space-physics/NEXRADutils
   description: Download/Plot NEXRAD compositive reflectivity by date/time, for ionospheric perturbations


### PR DESCRIPTION
MadrigalWeb is a pure python module to access data from any Madrigal database. Supported data formats include ascii, netcdf4, and hdf5.  

PyHC-standards-evaluator report:

[madrigalWeb_PyHC_Evaluation.md](https://github.com/user-attachments/files/31275482/madrigalWeb_PyHC_Evaluation.md)
