### PR TITLE
add SWVO to PyHC

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -740,6 +740,19 @@
   python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
   license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
 
+- name: "SWVO"
+  description: "Tools for downloading and reading space-weather data and geomagnetic indices."
+  docs: "https://swvo.readthedocs.io/en/latest/"
+  code: "https://github.com/GFZ/SWVO"
+  contact: "Sahil Jhawar (jhawar@gfz.de), Bernhard Haas (bhaas@gfz.de)"
+  keywords: ["heliosphere", "magnetosphere", "solar", "ionosphere_thermosphere_mesosphere", "plasma_physics", "data_access", "data_retrieval", "reference_data", "csv", "netcdf", "ascii", "coordinates", "time", "remote", "local", "web_service", "general", "ace", "dscovr", "omni", "enlil"]
+  community: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  documentation: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  testing: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  software_maturity: ["https://img.shields.io/badge/Partially%20met-orange.svg", "Partially met"]
+  python3: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+  license: ["https://img.shields.io/badge/Good-brightgreen.svg", "Good"]
+
 - name: "swxsoc"
   url: "https://swxsoc.github.io/"
   description: "Pipeline and analysis tools for space weather data processing."


### PR DESCRIPTION
# Add SWVO to the PyHC project list

  Adds SWVO (https://github.com/GFZ/SWVO) to _data/projects.yml.

  SWVO is a Python package for downloading and reading space-weather data and geomagnetic indices (Kp, Dst, Hp, F10.7, SuperMAG electrojet/substorm indices, solar wind parameters from ACE/DSCOVR/OMNI/ENLIL, and plasmasphere density predictions).

  Self-assessed grades:
  - Community: Good
  - Documentation: Good
  - Testing: Good
  - Software Maturity: Partially met
  - PHEP 3: Good
  - License: Good

Here's the evaluation doc: [SWVO_PyHC_Evaluation.md](https://github.com/user-attachments/files/31835349/SWVO_PyHC_Evaluation.md)

  Contact: Sahil Jhawar (jhawar@gfz.de), Bernhard Haas (bhaas@gfz.de)
